### PR TITLE
added muon in jet correction

### DIFF
--- a/Root/BalanceAlgorithm.cxx
+++ b/Root/BalanceAlgorithm.cxx
@@ -560,7 +560,7 @@ EL::StatusCode BalanceAlgorithm :: muonInJetCorrection (const xAOD::JetContainer
       muonInJetP4 = getFourMomentumOfMuonInJet (closestMuon);
     }
     
-    TLorentzVector correctedJetP4 = (jetP4+muonInJetP4);
+    const TLorentzVector correctedJetP4 = (jetP4+muonInJetP4);
     
     signalJet->auxdecor< float >("mucorrected_pt")  = correctedJetP4.Pt();
     signalJet->auxdecor< float >("mucorrected_phi") = correctedJetP4.Phi();
@@ -585,7 +585,7 @@ TLorentzVector BalanceAlgorithm :: getFourMomentumOfMuonInJet (const xAOD::Muon*
   const double eLossY=eLoss*sin(theta)*sin(phi);
   const double eLossZ=eLoss*cos(theta);
   
-  TLorentzVector eLossP4(eLossX,eLossY,eLossZ,eLoss);  
+  const TLorentzVector eLossP4(eLossX,eLossY,eLossZ,eLoss);  
   
   return muonP4-eLossP4;
 }

--- a/Root/BalanceAlgorithm.cxx
+++ b/Root/BalanceAlgorithm.cxx
@@ -542,28 +542,16 @@ EL::StatusCode BalanceAlgorithm :: muonInJetCorrection (const xAOD::JetContainer
 	       HelperFunctions::retrieve(muonsForCorr, m_inputMuonForMuonInJetCorrectionContainerName, m_event, m_store), "");
   
   for( auto signalJet : *signalJets ) {
-    const double pt  = signalJet->pt();
-    const double eta = signalJet->eta();
-    const double phi = signalJet->phi();
-    const double m   = signalJet->m();
-    TLorentzVector jetP4;
-    jetP4.SetPtEtaPhiM(pt, eta, phi, m);
+    const TLorentzVector& jetP4 = signalJet->p4();
     
-    xAOD::MuonContainer::const_iterator muItrC = muonsForCorr->begin();
-    xAOD::MuonContainer::const_iterator muItrE = muonsForCorr->end();
     double minimumDr = 0.4;
     const xAOD::Muon* closestMuon = 0;
-    for (; muItrC!=muItrE; muItrC++) {
-      const double mu_pt  = (*muItrC)->pt();
-      const double mu_eta = (*muItrC)->eta();
-      const double mu_phi = (*muItrC)->phi();
-      const double mu_m   = (*muItrC)->m();
-      TLorentzVector muonP4;
-      muonP4.SetPtEtaPhiM(mu_pt, mu_eta, mu_phi, mu_m);
+    for ( auto muon : *muonsForCorr ) {
+      const TLorentzVector& muonP4 = muon->p4();
       const double dR = jetP4.DeltaR(muonP4);
       if (dR<minimumDr) {
 	minimumDr   = dR;
-	closestMuon = (*muItrC);
+	closestMuon = muon;
       }
     }
     
@@ -588,17 +576,14 @@ TLorentzVector BalanceAlgorithm :: getFourMomentumOfMuonInJet (const xAOD::Muon*
 {
   float eLoss=0.0;
   muon->parameter(eLoss,xAOD::Muon::EnergyLoss);
-  TLorentzVector muonP4;
-  const double pt  = muon->pt();
-  const double eta = muon->eta();
-  const double phi = muon->phi();
-  const double m   = muon->m();
-  muonP4.SetPtEtaPhiM(pt, eta, phi, m);
+  const TLorentzVector& muonP4 = muon->p4();
   
-  double theta=muonP4.Theta();
-  double eLossX=eLoss*sin(theta)*cos(phi);
-  double eLossY=eLoss*sin(theta)*sin(phi);
-  double eLossZ=eLoss*cos(theta);
+  const double theta=muonP4.Theta();
+  const double phi  =muonP4.Phi();
+  
+  const double eLossX=eLoss*sin(theta)*cos(phi);
+  const double eLossY=eLoss*sin(theta)*sin(phi);
+  const double eLossZ=eLoss*cos(theta);
   
   TLorentzVector eLossP4(eLossX,eLossY,eLossZ,eLoss);  
   

--- a/Root/MiniTree.cxx
+++ b/Root/MiniTree.cxx
@@ -22,7 +22,7 @@ void MiniTree::AddEventUser(const std::string detailStr)
   m_tree->Branch("Zeta",  &m_Zeta,  "Zeta/F" );
   m_tree->Branch("Zphi",  &m_Zphi,  "Zphi/F" );
   m_tree->Branch("ZM",    &m_ZM,    "ZM/F"   );
-
+  
 
   m_tree->Branch("weight", &m_weight, "weight/F");
   m_tree->Branch("weight_xs", &m_weight_xs, "weight_xs/F");
@@ -33,6 +33,10 @@ void MiniTree::AddJetsUser(const std::string detailStr)
 {
   m_tree->Branch("jet_constitScaleEta", &m_jet_constitScaleEta);
   m_tree->Branch("jet_emScaleEta", &m_jet_emScaleEta);
+  m_tree->Branch("jet_mucorrected_pt", &m_jet_mucorrected_pt);
+  m_tree->Branch("jet_mucorrected_eta", &m_jet_mucorrected_eta);
+  m_tree->Branch("jet_mucorrected_phi", &m_jet_mucorrected_phi);
+  m_tree->Branch("jet_mucorrected_m",  &m_jet_mucorrected_m);
 }
 
 //////////////////// Clear any defined vectors here ////////////////////////////
@@ -51,6 +55,10 @@ void MiniTree::ClearEventUser() {
 void MiniTree::ClearJetsUser() {
   m_jet_constitScaleEta.clear();
   m_jet_emScaleEta.clear();
+  m_jet_mucorrected_pt.clear();
+  m_jet_mucorrected_eta.clear();
+  m_jet_mucorrected_phi.clear();
+  m_jet_mucorrected_m.clear();
 }
 
 /////////////////// Assign values to defined event variables here ////////////////////////
@@ -86,6 +94,10 @@ void MiniTree::FillJetsUser( const xAOD::Jet* jet ) {
   } else {
     m_jet_emScaleEta.push_back( -999 );
   }
-
+  
+  m_jet_mucorrected_pt.push_back(jet->auxdata< float >("mucorrected_pt")/m_units);
+  m_jet_mucorrected_eta.push_back(jet->auxdata< float >("mucorrected_eta"));
+  m_jet_mucorrected_phi.push_back(jet->auxdata< float >("mucorrected_phi"));
+  m_jet_mucorrected_m.push_back(jet->auxdata< float >("mucorrected_m")/m_units);
 }
 

--- a/ZJetBalance/BalanceAlgorithm.h
+++ b/ZJetBalance/BalanceAlgorithm.h
@@ -46,6 +46,8 @@ class BalanceAlgorithm : public xAH::Algorithm
     std::string m_inputJetAlgo;             //! input algo for when running systs
     std::string m_inputMuonContainerName;   //! input container name
     std::string m_inputMuonAlgo;            //! input algo for when running systs
+    std::string m_inputMuonForMuonInJetCorrectionContainerName; //! input container name
+    std::string m_inputMuonForMuonInJetCorrectionAlgo;          //! input algo for when running systs
     bool m_isMC;                      //! Is MC
     bool m_useCutFlow;                //! true will write out cutflow histograms
     bool m_writeTree;                 //! true will write out a TTree
@@ -66,6 +68,8 @@ class BalanceAlgorithm : public xAH::Algorithm
 
     std::string m_treeStream;
     void passCut();
+    TLorentzVector getFourMomentumOfMuonInJet(const xAOD::Muon* muon);
+    EL::StatusCode muonInJetCorrection (const xAOD::JetContainer* signalJets);
 
 #ifndef __CINT__
     EL::StatusCode getLumiWeights(const xAOD::EventInfo* eventInfo);

--- a/ZJetBalance/MiniTree.h
+++ b/ZJetBalance/MiniTree.h
@@ -21,8 +21,11 @@ class MiniTree : public HelpTreeBase
 
     std::vector<float> m_jet_constitScaleEta;
     std::vector<float> m_jet_emScaleEta;
-
-
+    std::vector<float> m_jet_mucorrected_pt;
+    std::vector<float> m_jet_mucorrected_eta;
+    std::vector<float> m_jet_mucorrected_phi;
+    std::vector<float> m_jet_mucorrected_m;
+    
   public:
 
     MiniTree(xAOD::TEvent * event, TTree* tree, TFile* file);

--- a/data/muonSelectForMuonInJetCorrection.config
+++ b/data/muonSelectForMuonInJetCorrection.config
@@ -1,0 +1,19 @@
+MuonQualiyt	    Medium
+##
+InputContainer      Muons_Calib
+InputAlgoSystNames  Muons_Calib_Algo
+CreateSelectedContainer True
+OutputContainer     MuonsForCorrection
+OutputAlgoSystNames MuonsForCorrection_Algo
+## 
+PassMin             0
+PassMax             -1
+## 
+pTMin               4e3
+etaMax              2.5
+## check this!
+DoIsolationCut      False
+IsolationWP         Tight
+#TrackBasedIsoType   ptvarcone20
+#TrackBasedIsoCut    0.05
+# new line needed at end #

--- a/data/zjetAlgo.config
+++ b/data/zjetAlgo.config
@@ -6,6 +6,8 @@ InputJetContainer          SignalJets
 InputJetAlgo               SignalJets_Algo
 InputMuonContainer         SignalMuons
 InputMuonAlgo              SignalMuons_Algo
+InputMuonForMuonInJetCorrectionContainer    MuonsForCorrection
+InputMuonForMuonInJetCorrectionAlgo         MuonsForCorrection_Algo
 LeadingJetPtCut            20000
 #Container for checking MC for pileup jets, important for JZ0W.  Set to "None" for no cut
 EventDetailStr             "truth pileup shapeEM"

--- a/util/runZBJetBalance.cxx
+++ b/util/runZBJetBalance.cxx
@@ -272,6 +272,9 @@ int main( int argc, char* argv[] ) {
   MuonSelector* muonSelect = new MuonSelector();
   muonSelect->setName( "muonSelect" )->setConfig( "$ROOTCOREBIN/data/ZJetBalance/muonSelect.config");
 
+  MuonSelector* muonSelectForMuonInJetCorrection = new MuonSelector();
+  muonSelectForMuonInJetCorrection->setName( "muonSelect" )->setConfig( "$ROOTCOREBIN/data/ZJetBalance/muonSelectForMuonInJetCorrection.config");
+
   MuonEfficiencyCorrector* muonCorrect = new MuonEfficiencyCorrector();
   muonCorrect->setName( "muonCorrect" )->setConfig( "$ROOTCOREBIN/data/ZJetBalance/muonCorrect.config");
 
@@ -304,7 +307,8 @@ int main( int argc, char* argv[] ) {
   job.algsAdd( baseEventSel );
   job.algsAdd( muonCalib    );
   job.algsAdd( muonSelect   );
-  job.algsAdd( muonCorrect  );
+  job.algsAdd( muonSelectForMuonInJetCorrection   );
+  //job.algsAdd( muonCorrect  ); // commented out to avoid crash so far
   job.algsAdd( jetCalib     );
   job.algsAdd( jetSelect    );
   job.algsAdd( bjetCorrect  );


### PR DESCRIPTION
Muon-in-jet correction has been implemented in Yasu's branch

Basic concept :
1. run the muon selector with the dedicated selection criteria 
2. using the muons, add new variable of four momentum after the correction in selected_Jet
3. it is stored in the final ntuple 
