### PR TITLE
Lepton quality cut modification

### DIFF
--- a/data/electronSelect.config
+++ b/data/electronSelect.config
@@ -8,7 +8,7 @@ OutputContainer     		SignalElectrons
 OutputAlgoSystNames 		SignalElectrons_Algo
 ##
 PassMin 					2
-pTMin 						10e3
+pTMin 						25e3
 etaMax 						2.47
 VetoCrack 					True
 d0sigMax 					5.0
@@ -16,7 +16,7 @@ z0sinthetaMax 				1.5
 ConfDirPID 					mc15_20150712
 ##
 DoLHPIDCut 					True
-LHOperatingPoint 			Tight
+LHOperatingPoint 			Medium
 LHConfigYear 				2015
 ##
 DoCutBasedPIDCut 			True
@@ -24,7 +24,7 @@ CutBasedOperatingPoint 		IsEMTight
 CutBasedConfigYear 			
 ##
 DoIsolationCut 				True
-IsolationWP 				Tight
+IsolationWP 				Gradient
 ##
 ElTrigChains 
 ##

--- a/data/muonSelect.config
+++ b/data/muonSelect.config
@@ -7,12 +7,14 @@ OutputAlgoSystNames SignalMuons_Algo
 PassMin             2
 PassMax             -1
 ## 
-pTMin               20e3
+pTMin               25e3
 etaMax              2.4
 DoIsolationCut      True
-IsolationWP         Tight
+IsolationWP         Gradient
 SingleMuTrigChain   HLT_mu20_iloose_L1MU15
 MinDeltaR           0.1
+MuonQuality	    Medium
+
 #DiMuTrigChain     
 Debug				False
 # new line needed at end #


### PR DESCRIPTION
Just to adjust with W/Z conf note 
( https://cds.cern.ch/record/2040062/files/ATL-COM-PHYS-2015-814.pdf )

Modifications:
- pT > 25 GeV
- ID medium (electonr = Tight -> Medium, Muon Medium -> Medium)
- Isolation Gradient 

Best regards,
Yasu Okumura
