### PR TITLE
MiniTree analysis base class is added

### DIFF
--- a/Root/LinkDef.h
+++ b/Root/LinkDef.h
@@ -1,6 +1,10 @@
-#include <ZJetBalance/ProcessZJetBalanceMiniTree.h>
 #include <ZJetBalance/BalanceAlgorithm.h>
 #include <ZJetBalance/MiniTree.h>
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaBase.h>
+#include <ZJetBalance/ProcessZJetBalanceMiniTree.h>
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h>
+#include <ZJetBalance/ZJetBalanceMiniTree_GenBalanceHistograms.h>
+
 
 #ifdef __CINT__
 
@@ -16,4 +20,7 @@
 
 #ifdef __CINT__
 #pragma link C++ class ProcessZJetBalanceMiniTree+;
+#pragma link C++ class ZJetBalanceMiniTreeAnaBase+;
+#pragma link C++ class ZJetBalanceMiniTreeAnaSkeleton;
+#pragma link C++ class ZJetBalanceMiniTree_GenBalanceHistograms;
 #endif

--- a/Root/ZJetBalanceMiniTreeAnaBase.cxx
+++ b/Root/ZJetBalanceMiniTreeAnaBase.cxx
@@ -240,11 +240,11 @@ void ZJetBalanceMiniTreeAnaBase::InitializeCutflows()
   int xminCutflow  = cutflows.first->GetXaxis()->GetXmin();
   int xmaxCutflow  = cutflows.first->GetXaxis()->GetXmax();
   
-  m_h_cutflow = new TH1F("cutflow", "", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow = new TH1F(Form("%scutflow",m_histPrefix.c_str()), "", nBinsCutflow, xminCutflow, xmaxCutflow);
   m_h_cutflow->SetCanExtend( TH1::kXaxis );
-  m_h_cutflow_weighted = new TH1F("cutflow_weighted", "ONLY MC WEIGHT given by generator", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow_weighted = new TH1F(Form("%scutflow_weighted",m_histPrefix.c_str()), "ONLY MC WEIGHT given by generator", nBinsCutflow, xminCutflow, xmaxCutflow);
   m_h_cutflow_weighted->SetCanExtend( TH1::kXaxis );
-  m_h_cutflow_weighted_final = new TH1F("cutflow_weighted_final", "", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow_weighted_final = new TH1F(Form("%scutflow_weighted_final",m_histPrefix.c_str()), "", nBinsCutflow, xminCutflow, xmaxCutflow);
   m_h_cutflow_weighted_final->SetCanExtend( TH1::kXaxis );
   
   wk()->addOutput( m_h_cutflow );

--- a/Root/ZJetBalanceMiniTreeAnaBase.cxx
+++ b/Root/ZJetBalanceMiniTreeAnaBase.cxx
@@ -1,0 +1,719 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/Worker.h>
+#include <EventLoop/OutputStream.h>
+#include <AthContainers/ConstDataVector.h>
+
+#include <xAODTracking/VertexContainer.h>
+#include <xAODJet/JetContainer.h>
+#include <xAODEventInfo/EventInfo.h>
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaBase.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+
+#include <TFile.h>
+#include <TKey.h>
+#include <TLorentzVector.h>
+#include <TEnv.h>
+#include <TSystem.h>
+
+#include <utility>      
+#include <iostream>
+#include <fstream>
+
+#include <stdlib.h>
+
+using namespace std;
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(ZJetBalanceMiniTreeAnaBase)
+
+ZJetBalanceMiniTreeAnaBase :: ZJetBalanceMiniTreeAnaBase ()
+{
+  Info("ZJetBalanceMiniTreeAnaBase()", "Calling constructor");
+}
+
+EL::StatusCode  ZJetBalanceMiniTreeAnaBase :: configure ()
+{
+  Info("configure()", "Called");
+  if (this->LoadBasicConfiguration()==EL::StatusCode::FAILURE) {
+    Error("configure()", "failed in LoadBasicConfiguration()");
+    return EL::StatusCode::FAILURE;
+  }
+  
+  Info("configure()", "Ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: setupJob (EL::Job& job)
+{
+  Info("setupJob()", "called");
+  // Here you put code that sets up the job on the submission object
+  // so that it is ready to work with your algorithm, e.g. you can
+  // request the D3PDReader service or add output files.  Any code you
+  // put here could instead also go into the submission script.  The
+  // sole advantage of putting it here is that it gets automatically
+  // activated/deactivated when you add/remove the algorithm from your
+  // job, which may or may not be of value to you.
+  
+  Info("setupJob()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: histInitialize ()
+{
+  // Here you do everything that needs to be done at the very
+  // beginning on each worker node, e.g. create histograms and output
+  // trees.  This method gets called before any input files are
+  // connected.
+  Info("histInitialize()", "called");
+  this->InitializeCutflows();
+  // histogram record will be done at the end of initialize()
+  
+  Info("histInitialize()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: fileExecute ()
+{
+  Info("fileExecute()", "called");
+  // Here you do everything that needs to be done exactly once for every
+  // single file, e.g. collect a list of all lumi-blocks processed
+  Info("fileExecute()", "end");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: changeInput (bool firstFile)
+{
+  Info("changedInput", "called"); 
+  
+  // Here you do everything you need to do when we change input files,
+  // e.g. resetting branch addresses on trees.  If you are using
+  // D3PDReader or a similar service this method is not needed.
+  
+  const std::pair<TH1F*, TH1F*> cutflows = ReturnCutflowPointers();  
+  // if first time through - need to set bin labels
+  if ( m_h_cutflow->GetXaxis()->GetBinLabel(1) != cutflows.first->GetXaxis()->GetBinLabel(1) ) {
+    std::cout << "Labels do not agree" << std::endl;
+    for (int iBin=1, nBins=cutflows.first->GetNbinsX(); iBin<=nBins; iBin++) {
+      if( std::string(cutflows.first->GetXaxis()->GetBinLabel(iBin)) == "" ) { continue; }
+      m_h_cutflow->GetXaxis()->SetBinLabel( iBin, 
+          cutflows.first->GetXaxis()->GetBinLabel(iBin) );
+      m_h_cutflow_weighted->GetXaxis()->SetBinLabel( iBin, 
+          cutflows.first->GetXaxis()->GetBinLabel(iBin) );
+      m_h_cutflow_weighted_final->GetXaxis()->SetBinLabel( iBin, 
+          cutflows.first->GetXaxis()->GetBinLabel(iBin) );
+      std::cout << "\t" << cutflows.first->GetXaxis()->GetBinLabel(iBin)  << std::endl;
+    }
+  }
+  
+  for (int iBin=1, nBins=m_h_cutflow->GetNbinsX(); iBin<=nBins; iBin++) { // update
+    m_h_cutflow->SetBinContent(iBin, m_h_cutflow->GetBinContent(iBin)+cutflows.first->GetBinContent(iBin)); 
+    Info("changeInput()", "iBin=%2d/%-2d new cutflow entry=%.1f (%s)", iBin, nBins, m_h_cutflow->GetBinContent(iBin), m_h_cutflow->GetXaxis()->GetBinLabel(iBin));
+  }
+  for (int iBin=1, nBins=m_h_cutflow_weighted->GetNbinsX(); iBin<=nBins; iBin++) { // update
+    m_h_cutflow_weighted->SetBinContent(iBin, m_h_cutflow_weighted->GetBinContent(iBin)+cutflows.second->GetBinContent(iBin)); 
+    Info("changeInput()", "iBin=%2d/%-2d new cutflow entry=%.1f (%s) - weighted ", iBin, nBins, m_h_cutflow_weighted->GetBinContent(iBin), m_h_cutflow_weighted->GetXaxis()->GetBinLabel(iBin));
+  }
+  
+  TTree *tree = wk()->tree();
+  InitTree(tree);
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: initialize ()
+{
+  Info("initialize()", "Calling initialize");
+
+  // Here you do everything that you need to do after the first input
+  // file has been connected and before the first event is processed,
+  // e.g. create additional histograms based on which variables are
+  // available in the input files.  You can also create all of your
+  // histograms and trees in here, but be aware that this method
+  // doesn't get called if no events are processed.  So any objects
+  // you create here won't be available in the output if you have no
+  // input events.
+  m_isMC          =  false;
+  m_eventCounter  =  0;
+  mcChannelNumber = -1; // needs for isMC decision
+  
+  // configuration from ENV file
+  if ( this->configure() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed to properly configure. Exiting." );
+    return EL::StatusCode::FAILURE;
+  }
+  
+  // Pileup RW Tool //
+  if (this->InitializePileupReweightingTool() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed in pileup RW tool initialization" );
+    return EL::StatusCode::FAILURE;      
+  }
+  
+  // pass all histograms instanted with the book function are passed
+  // to the worker through 
+  this->record( wk() );
+  
+  Info("initialize()", "Succesfully initialized! \n");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: execute ()
+{
+  // Here you do everything that needs to be done on every single
+  // event, e.g. read input variables, apply cuts, and fill
+  // histograms and trees.  This is where most of your actual analysis
+  // code will go.
+  this->LoadMiniTree();
+  
+  double weight_final=1.0;
+  if (m_isMC) {
+    double pileup_reweighting_factor = GetPileupReweightingFactor();
+    weight_final = 
+      mcEventWeight*weight_xs*pileup_reweighting_factor*m_additional_weight;
+  }
+  
+  // use non-weighted to check that the correct number of events was processes
+  // use weighted to see the effect of the weights calculated in xAH
+  FillCutflowHistograms("Process NTuple", mcEventWeight, weight_final);
+  
+  
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: postExecute ()
+{
+  // Here you do everything that needs to be done after the main event
+  // processing.  This is typically very rare, particularly in user
+  // code.  It is mainly used in implementing the NTupleSvc.
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: finalize ()
+{
+  // This method is the mirror image of initialize(), meaning it gets
+  // called after the last event has been processed on the worker node
+  // and allows you to finish up any objects you created in
+  // initialize() before they are written to disk.  This is actually
+  // fairly rare, since this happens separately for each worker node.
+  // Most of the time you want to do your post-processing on the
+  // submission node after all your histogram outputs have been
+  // merged.  This is different from histFinalize() in that it only
+  // gets called on worker nodes that processed input events.
+  std::cout << "Finialize!" << std::endl;
+  
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase :: histFinalize ()
+{
+  // This method is the mirror image of histInitialize(), meaning it
+  // gets called after the last event has been processed on the worker
+  // node and allows you to finish up any objects you created in
+  // histInitialize() before they are written to disk.  This is
+  // actually fairly rare, since this happens separately for each
+  // worker node.  Most of the time you want to do your
+  // post-processing on the submission node after all your histogram
+  // outputs have been merged.  This is different from finalize() in
+  // that it gets called on all worker nodes regardless of whether
+  // they processed input events.
+  return EL::StatusCode::SUCCESS;
+}
+
+void ZJetBalanceMiniTreeAnaBase::InitializeCutflows()
+{
+  const std::pair<TH1F*, TH1F*> cutflows = ReturnCutflowPointers();
+  int nBinsCutflow = cutflows.first->GetNbinsX();
+  int xminCutflow  = cutflows.first->GetXaxis()->GetXmin();
+  int xmaxCutflow  = cutflows.first->GetXaxis()->GetXmax();
+  
+  m_h_cutflow = new TH1F("cutflow", "", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow->SetCanExtend( TH1::kXaxis );
+  m_h_cutflow_weighted = new TH1F("cutflow_weighted", "ONLY MC WEIGHT given by generator", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow_weighted->SetCanExtend( TH1::kXaxis );
+  m_h_cutflow_weighted_final = new TH1F("cutflow_weighted_final", "", nBinsCutflow, xminCutflow, xmaxCutflow);
+  m_h_cutflow_weighted_final->SetCanExtend( TH1::kXaxis );
+  
+  wk()->addOutput( m_h_cutflow );
+  wk()->addOutput( m_h_cutflow_weighted );
+  wk()->addOutput( m_h_cutflow_weighted_final );
+}
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase::InitializePileupReweightingTool()
+{
+  m_pileuptool = new CP::PileupReweightingTool("Pileup");
+  
+  std::vector<std::string> PRWFiles;
+  std::vector<std::string> lumiCalcFiles;
+    
+  std::string tmp_lumiCalcFileNames = m_lumiCalcFileNames;
+  std::string tmp_PRWFileNames = m_PRWFileNames;
+    
+  // Parse all comma seperated files
+  while( tmp_PRWFileNames.size() > 0){
+    std::string::size_type pos = tmp_PRWFileNames.find_first_of(',');
+    if( pos == std::string::npos){
+      pos = tmp_PRWFileNames.size();
+      PRWFiles.push_back( gSystem->ExpandPathName( (tmp_PRWFileNames.substr(0, pos)).c_str() ) );
+      tmp_PRWFileNames.erase(0, pos);
+    }else{
+      PRWFiles.push_back( gSystem->ExpandPathName( (tmp_PRWFileNames.substr(0, pos)).c_str() ) );
+      tmp_PRWFileNames.erase(0, pos+1);
+    }
+  }
+  while( tmp_lumiCalcFileNames.size() > 0){
+    std::string::size_type pos = tmp_lumiCalcFileNames.find_first_of(',');
+    if( pos == std::string::npos){
+      pos = tmp_lumiCalcFileNames.size();
+      lumiCalcFiles.push_back(tmp_lumiCalcFileNames.substr(0, pos));
+      tmp_lumiCalcFileNames.erase(0, pos);
+    }else{
+      lumiCalcFiles.push_back(tmp_lumiCalcFileNames.substr(0, pos));
+      tmp_lumiCalcFileNames.erase(0, pos+1);
+    }
+  }
+
+  std::cout << "PileupReweighting Tool is adding Pileup files:" << std::endl;
+  for( unsigned int i=0; i < PRWFiles.size(); ++i){
+    std::cout << "    " << PRWFiles.at(i) << std::endl;
+  }
+  std::cout << "PileupReweighting Tool is adding Lumi Calc files:" << std::endl;
+  for( unsigned int i=0; i < lumiCalcFiles.size(); ++i){
+    std::cout << "    " << lumiCalcFiles.at(i) << std::endl;
+  }
+    
+  RETURN_CHECK("ZJetBalance::initialize()", m_pileuptool->setProperty("ConfigFiles", PRWFiles), "");
+  RETURN_CHECK("ZJetBalance::initialize()", m_pileuptool->setProperty("LumiCalcFiles", lumiCalcFiles), "");
+  RETURN_CHECK("ZJetBalance::initialize()", m_pileuptool->initialize(), "");
+  std::cout << "ZJetBalance::initialize() Initialized PileupReweightingTool " << m_pileuptool->name() << std::endl; 
+  
+  return EL::StatusCode::SUCCESS;
+}
+
+void ZJetBalanceMiniTreeAnaBase::LoadMiniTree()
+{
+  //===============================
+  // load tree
+  //===============================
+  TTree* tree = wk()->tree();
+  if(m_btagJets) { if(!jet_isBTag || !jet_SFBTag) { this->SetBTagAddresses(tree); } }
+  const int jentry = wk()->treeEntry();
+  tree->LoadTree (jentry);
+  tree->GetEntry (jentry);
+  
+  m_isMC = (mcChannelNumber!=-1);  
+}
+
+
+double ZJetBalanceMiniTreeAnaBase::GetPileupReweightingFactor()
+{
+  // what actually done in getCombinedWeight( const xAOD::EventInfo& eventInfo )
+  // PileupReweighting/Root/PileupReweightingTool.cxx
+  return ((m_doPUreweighting) ? 
+	  m_pileuptool->GetCombinedWeight(runNumber, mcChannelNumber, averageInteractionsPerCrossing) :
+	  1.0);
+}
+
+std::pair<TH1F*, TH1F*> ZJetBalanceMiniTreeAnaBase::ReturnCutflowPointers()
+{
+  std::pair<TH1F*, TH1F*> rc(0, 0);
+  
+  TFile* inputFile = wk()->inputFile();
+  TIter next(inputFile->GetListOfKeys());
+  TKey *key;
+  while ((key = (TKey*)next())) {
+    std::string keyName = key->GetName();
+    
+    std::size_t found = keyName.find("cutflow");
+    bool foundCutFlow = (found!=std::string::npos);
+    
+    found = keyName.find("weighted");
+    bool foundWeighted = (found!=std::string::npos);
+    
+    if(foundCutFlow && !foundWeighted){
+      rc.first  = ((TH1F*)key->ReadObj());
+    } else if(foundCutFlow && foundWeighted) {
+      rc.second = ((TH1F*)key->ReadObj());
+    }
+  }//over Keys
+  
+  // rebin
+  int nValidBins=0;
+  // if first time through - need to set bin labels
+  for (int iBin=1, nBins=rc.first->GetNbinsX(); iBin<=nBins; iBin++) {
+    if( std::string(rc.first->GetXaxis()->GetBinLabel(iBin)) == "" ) { continue; }
+    nValidBins++;
+  }
+  
+  // reset bins = in order to avoid bins without label set (needed for TH1::FindBin(label) function )
+  Info("ReturnCutflowPointers()", "New Binning nBins=%d min=%f max=%f", nValidBins, 0.5, nValidBins+0.5);
+  rc.first->SetBins(nValidBins, 0.5, nValidBins+0.5);
+  rc.second->SetBins(nValidBins, 0.5, nValidBins+0.5);
+
+  return rc;
+}
+
+
+
+TH1F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+                             std::string xlabel, int xbins, double xlow, double xhigh)
+{
+  TH1F* tmp = new TH1F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xlow, xhigh);
+  SetLabel(tmp, xlabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+TH2F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+                             std::string xlabel, int xbins, double xlow, double xhigh,
+                             std::string ylabel, int ybins, double ylow, double yhigh)
+{
+  TH2F* tmp = new TH2F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xlow, xhigh, ybins, ylow, yhigh);
+  SetLabel(tmp, xlabel, ylabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+
+/////// Variable Binned Histograms ///////
+TH1F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+    std::string xlabel, int xbins, const Double_t* xbinArr)
+{
+  TH1F* tmp = new TH1F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xbinArr);
+  SetLabel(tmp, xlabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+TH2F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+    std::string xlabel, int xbins, const Double_t* xbinArr,
+    std::string ylabel, int ybins, double ylow, double yhigh)
+{
+  TH2F* tmp = new TH2F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xbinArr, ybins, ylow, yhigh);
+  SetLabel(tmp, xlabel, ylabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+TH2F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+    std::string xlabel, int xbins, double xlow, double xhigh,
+    std::string ylabel, int ybins, const Double_t* ybinArr)
+{
+  TH2F* tmp = new TH2F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xlow, xhigh, ybins, ybinArr);
+  SetLabel(tmp, xlabel, ylabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+TH2F* ZJetBalanceMiniTreeAnaBase::book(std::string name,
+    std::string xlabel, int xbins, const Double_t* xbinArr,
+    std::string ylabel, int ybins, const Double_t* ybinArr)
+{
+  TH2F* tmp = new TH2F( (m_histPrefix+name).c_str(), name.c_str(), xbins, xbinArr, ybins, ybinArr);
+  SetLabel(tmp, xlabel, ylabel);
+  this->Sumw2(tmp);
+  this->record(tmp);
+  return tmp;
+}
+
+void ZJetBalanceMiniTreeAnaBase::Sumw2(TH1* hist, bool flag /*=true*/) {
+  hist->Sumw2(flag);
+}
+
+void ZJetBalanceMiniTreeAnaBase::SetLabel(TH1* hist, std::string xlabel)
+{
+  hist->GetXaxis()->SetTitle(xlabel.c_str());
+}
+
+void ZJetBalanceMiniTreeAnaBase::SetLabel(TH1* hist, std::string xlabel, std::string ylabel)
+{
+  hist->GetYaxis()->SetTitle(ylabel.c_str());
+  this->SetLabel(hist, xlabel);
+}
+
+void ZJetBalanceMiniTreeAnaBase::record(TH1* hist) {
+  m_allHists.push_back( hist );
+}
+
+void ZJetBalanceMiniTreeAnaBase::record(EL::Worker* wk) {
+  for( auto hist : m_allHists ){
+    Info("record()", "histogram record : %s", hist->GetName());
+    wk->addOutput(hist);
+  }
+}
+
+void ZJetBalanceMiniTreeAnaBase::FillCutflowHistograms(const std::string& label, const double& xAHWeight, const double& weightFinal)
+{
+  // create first for both
+  m_h_cutflow->GetXaxis()->FindBin(label.c_str());
+  m_h_cutflow_weighted->GetXaxis()->FindBin(label.c_str());
+  m_h_cutflow_weighted_final->GetXaxis()->FindBin(label.c_str());
+  
+  const int bin = m_h_cutflow->GetXaxis()->FindBin(label.c_str());
+  const double xx = m_h_cutflow->GetXaxis()->GetBinCenter(bin);
+  
+  m_h_cutflow->Fill( xx, 1 );
+  m_h_cutflow_weighted->Fill( xx, xAHWeight );
+  m_h_cutflow_weighted_final->Fill( xx, weightFinal );
+}
+
+EL::StatusCode ZJetBalanceMiniTreeAnaBase::LoadBasicConfiguration() 
+{
+  Info("LoadBasicConfiguration()", "called");
+  m_configName = gSystem->ExpandPathName( m_configName.c_str() );
+  Info("LoadBasicConfiguration()", "Configuing ZJetBalanceMiniTreeAnaBase Interface. User configuration read from : %s \n", m_configName.c_str());
+  TEnv* config = new TEnv(m_configName.c_str());
+  if( !config ) {
+    Error("configure()", "Failed to read config file!");
+    Error("configure()", "config name : %s",m_configName.c_str());
+    return EL::StatusCode::FAILURE;
+  }
+  
+  //
+  // Read Input from .config file
+  //
+  m_debug                    = config->GetValue("Debug" ,      false );
+  m_doPUreweighting          = config->GetValue("DoPileupReweighting", false);
+  m_lumiCalcFileNames        = config->GetValue("LumiCalcFiles", "");
+  m_PRWFileNames             = config->GetValue("PRWFiles", "");
+  m_additional_weight        = config->GetValue("AdditionalWeight", 1.0);
+  m_btagJets                 = config->GetValue("BTagJets", false);
+  m_btagOP                   = config->GetValue("BTagOP", "70"); // 85, 77, 70, 60
+  m_histPrefix               = config->GetValue("HistPrefix" ,      "" );
+  
+  if( m_btagJets ) {
+    if( m_btagOP != "85" && m_btagOP != "77" && m_btagOP != "70" && m_btagOP != "60" ) {
+      std::cout << "Invalid b-tag operating point " << m_btagOP << std::endl;
+      return EL::StatusCode::FAILURE;
+    }
+    std::cout << "BTagging using the " << m_btagOP << "% operating point" << std::endl;
+  }
+  
+  std::cout << "The basic configuration has been done in ZJetBalanceMiniTreeAnaBase :: LoadBasicConfiguration()" << std::endl;
+  std::cout << "   - m_debug             " << ((m_debug) ? "True" : "False") << std::endl;
+  std::cout << "   - m_doPUreweighting   " << ((m_doPUreweighting) ? "True" : "False") << std::endl;
+  std::cout << "   - m_lumiCalcFileNames " << m_lumiCalcFileNames << std::endl;
+  std::cout << "   - m_PRWFileNames      " << m_PRWFileNames << std::endl;
+  std::cout << "   - m_additional_weight " << m_additional_weight << std::endl;
+  std::cout << "   - m_btagJets          " << m_btagJets << std::endl;
+  std::cout << "   - m_btagOP            " << m_btagOP << std::endl;
+  std::cout << "   - m_histPrefix        " << m_histPrefix << std::endl;
+  
+  Info("LoadBasicConfiguration()", "ZJetBalanceMiniTreeAnaBase Interface succesfully configured! \n");
+  return EL::StatusCode::SUCCESS;
+}
+
+void ZJetBalanceMiniTreeAnaBase :: SetBTagAddresses(TTree* tree)
+{
+  if(!m_btagJets) { return; }
+  std::string btagAddress("jet_MV2c20_is"+m_btagOP);
+  std::string btagSFAddress("jet_MV2c20_SF"+m_btagOP);
+  tree->SetBranchAddress(btagAddress.c_str(),   &jet_isBTag, &b_jet_isBTag);
+  tree->SetBranchAddress(btagSFAddress.c_str(), &jet_SFBTag, &b_jet_SFBTag);
+  if( !(jet_isBTag && jet_SFBTag) ) {
+    std::cout << "CANNOT Set B-Tagging Branches : " << std::endl;
+    std::cout << "\t" << btagAddress.c_str() << std::endl;
+    std::cout << "\t" << btagSFAddress.c_str() << std::endl;
+  }
+  // FIXME - induce an exit
+}
+
+void ZJetBalanceMiniTreeAnaBase :: InitTree(TTree* tree)
+{
+  // Set object pointer
+  weight_muon_trig = 0;
+  jet_E = 0;
+  jet_pt = 0;
+  jet_phi = 0;
+  jet_eta = 0;
+  jet_rapidity = 0;
+  jet_HECFrac = 0;
+  jet_EMFrac = 0;
+  jet_CentroidR = 0;
+  jet_FracSamplingMax = 0;
+  jet_FracSamplingMaxIndex = 0;
+  jet_LowEtConstituentsFrac = 0;
+  jet_GhostMuonSegmentCount = 0;
+  jet_Width = 0;
+  jet_NumTrkPt1000PV = 0;
+  jet_SumPtTrkPt1000PV = 0;
+  jet_TrackWidthPt1000PV = 0;
+  jet_NumTrkPt500PV = 0;
+  jet_SumPtTrkPt500PV = 0;
+  jet_TrackWidthPt500PV = 0;
+  jet_JVFPV = 0;
+  jet_Jvt = 0;
+  jet_JvtJvfcorr = 0;
+  jet_JvtRpt = 0;
+  jet_SV0 = 0;
+  jet_SV1 = 0;
+  jet_IP3D = 0;
+  jet_SV1IP3D = 0;
+  jet_MV1 = 0;
+  jet_MV2c00 = 0;
+  jet_MV2c20 = 0;
+  jet_MV2c20_is85 = 0;
+  jet_MV2c20_SF85 = 0;
+  jet_MV2c20_is77 = 0;
+  jet_MV2c20_SF77 = 0;
+  jet_MV2c20_is70 = 0;
+  jet_MV2c20_SF70 = 0;
+  jet_MV2c20_is60 = 0;
+  jet_MV2c20_SF60 = 0;
+  jet_isBTag = 0;
+  jet_SFBTag = 0;
+  jet_GhostArea = 0;
+  jet_ActiveArea = 0;
+  jet_VoronoiArea = 0;
+  jet_ActiveArea4vec_pt = 0;
+  jet_ActiveArea4vec_eta = 0;
+  jet_ActiveArea4vec_phi = 0;
+  jet_ActiveArea4vec_m = 0;
+  jet_ConeTruthLabelID = 0;
+  jet_TruthCount = 0;
+  jet_TruthLabelDeltaR_B = 0;
+  jet_TruthLabelDeltaR_C = 0;
+  jet_TruthLabelDeltaR_T = 0;
+  jet_PartonTruthLabelID = 0;
+  jet_GhostTruthAssociationFraction = 0;
+  jet_truth_E = 0;
+  jet_truth_pt = 0;
+  jet_truth_phi = 0;
+  jet_truth_eta = 0;
+  jet_constitScaleEta = 0;
+  jet_emScaleEta = 0;
+  jet_mucorrected_pt = 0;
+  jet_mucorrected_eta = 0;
+  jet_mucorrected_phi = 0;
+  jet_mucorrected_m = 0;
+  muon_pt = 0;
+  muon_eta = 0;
+  muon_phi = 0;
+  muon_m = 0;
+  muon_effSF = 0;
+   
+  tree->SetBranchAddress("runNumber", &runNumber, &b_runNumber);
+  tree->SetBranchAddress("eventNumber", &eventNumber, &b_eventNumber);
+  tree->SetBranchAddress("mcEventNumber", &mcEventNumber, &b_mcEventNumber);
+  tree->SetBranchAddress("mcChannelNumber", &mcChannelNumber, &b_mcChannelNumber);
+  tree->SetBranchAddress("mcEventWeight", &mcEventWeight, &b_mcEventWeight);
+  tree->SetBranchAddress("weight_pileup", &weight_pileup, &b_weight_pileup);
+  tree->SetBranchAddress("NPV", &NPV, &b_NPV);
+  tree->SetBranchAddress("actualInteractionsPerCrossing", &actualInteractionsPerCrossing, &b_actualInteractionsPerCrossing);
+  tree->SetBranchAddress("averageInteractionsPerCrossing", &averageInteractionsPerCrossing, &b_averageInteractionsPerCrossing);
+  tree->SetBranchAddress("lumiBlock", &lumiBlock, &b_lumiBlock);
+  tree->SetBranchAddress("rhoEM", &rhoEM, &b_rhoEM);
+  tree->SetBranchAddress("pdgId1", &pdgId1, &b_pdgId1);
+  tree->SetBranchAddress("pdgId2", &pdgId2, &b_pdgId2);
+  tree->SetBranchAddress("pdfId1", &pdfId1, &b_pdfId1);
+  tree->SetBranchAddress("pdfId2", &pdfId2, &b_pdfId2);
+  tree->SetBranchAddress("x1", &x1, &b_x1);
+  tree->SetBranchAddress("x2", &x2, &b_x2);
+  tree->SetBranchAddress("xf1", &xf1, &b_xf1);
+  tree->SetBranchAddress("xf2", &xf2, &b_xf2);
+  tree->SetBranchAddress("ZpT", &ZpT, &b_ZpT);
+  tree->SetBranchAddress("Zeta", &Zeta, &b_Zeta);
+  tree->SetBranchAddress("Zphi", &Zphi, &b_Zphi);
+  tree->SetBranchAddress("ZM", &ZM, &b_ZM);
+  tree->SetBranchAddress("dPhiZJet1", &dPhiZJet1, &b_dPhiZJet1);
+  tree->SetBranchAddress("dEtaZJet1", &dEtaZJet1, &b_dEtaZJet1);
+  tree->SetBranchAddress("pTRef1", &pTRef1, &b_pTRef1);
+  tree->SetBranchAddress("dPhiZJet2", &dPhiZJet2, &b_dPhiZJet2);
+  tree->SetBranchAddress("dEtaZJet2", &dEtaZJet2, &b_dEtaZJet2);
+  tree->SetBranchAddress("pTRef2", &pTRef2, &b_pTRef2);
+  tree->SetBranchAddress("jetDPhi", &jetDPhi, &b_jetDPhi);
+  tree->SetBranchAddress("jetDEta", &jetDEta, &b_jetDEta);
+  tree->SetBranchAddress("jetPtRatio", &jetPtRatio, &b_jetPtRatio);
+  tree->SetBranchAddress("weight", &weight, &b_weight);
+  tree->SetBranchAddress("weight_xs", &weight_xs, &b_weight_xs);
+  tree->SetBranchAddress("weight_prescale", &weight_prescale, &b_weight_prescale);
+  tree->SetBranchAddress("weight_muon_trig", &weight_muon_trig, &b_weight_muon_trig);
+  tree->SetBranchAddress("njets", &njets, &b_njets);
+  tree->SetBranchAddress("jet_E", &jet_E, &b_jet_E);
+  tree->SetBranchAddress("jet_pt", &jet_pt, &b_jet_pt);
+  tree->SetBranchAddress("jet_phi", &jet_phi, &b_jet_phi);
+  tree->SetBranchAddress("jet_eta", &jet_eta, &b_jet_eta);
+  tree->SetBranchAddress("jet_rapidity", &jet_rapidity, &b_jet_rapidity);
+  tree->SetBranchAddress("jet_HECFrac", &jet_HECFrac, &b_jet_HECFrac);
+  tree->SetBranchAddress("jet_EMFrac", &jet_EMFrac, &b_jet_EMFrac);
+  tree->SetBranchAddress("jet_CentroidR", &jet_CentroidR, &b_jet_CentroidR);
+  tree->SetBranchAddress("jet_FracSamplingMax", &jet_FracSamplingMax, &b_jet_FracSamplingMax);
+  tree->SetBranchAddress("jet_FracSamplingMaxIndex", &jet_FracSamplingMaxIndex, &b_jet_FracSamplingMaxIndex);
+  tree->SetBranchAddress("jet_LowEtConstituentsFrac", &jet_LowEtConstituentsFrac, &b_jet_LowEtConstituentsFrac);
+  tree->SetBranchAddress("jet_GhostMuonSegmentCount", &jet_GhostMuonSegmentCount, &b_jet_GhostMuonSegmentCount);
+  tree->SetBranchAddress("jet_Width", &jet_Width, &b_jet_Width);
+  tree->SetBranchAddress("jet_NumTrkPt1000PV", &jet_NumTrkPt1000PV, &b_jet_NumTrkPt1000PV);
+  tree->SetBranchAddress("jet_SumPtTrkPt1000PV", &jet_SumPtTrkPt1000PV, &b_jet_SumPtTrkPt1000PV);
+  tree->SetBranchAddress("jet_TrackWidthPt1000PV", &jet_TrackWidthPt1000PV, &b_jet_TrackWidthPt1000PV);
+  tree->SetBranchAddress("jet_NumTrkPt500PV", &jet_NumTrkPt500PV, &b_jet_NumTrkPt500PV);
+  tree->SetBranchAddress("jet_SumPtTrkPt500PV", &jet_SumPtTrkPt500PV, &b_jet_SumPtTrkPt500PV);
+  tree->SetBranchAddress("jet_TrackWidthPt500PV", &jet_TrackWidthPt500PV, &b_jet_TrackWidthPt500PV);
+  tree->SetBranchAddress("jet_JVFPV", &jet_JVFPV, &b_jet_JVFPV);
+  tree->SetBranchAddress("jet_Jvt", &jet_Jvt, &b_jet_Jvt);
+  tree->SetBranchAddress("jet_JvtJvfcorr", &jet_JvtJvfcorr, &b_jet_JvtJvfcorr);
+  tree->SetBranchAddress("jet_JvtRpt", &jet_JvtRpt, &b_jet_JvtRpt);
+  tree->SetBranchAddress("jet_SV0", &jet_SV0, &b_jet_SV0);
+  tree->SetBranchAddress("jet_SV1", &jet_SV1, &b_jet_SV1);
+  tree->SetBranchAddress("jet_IP3D", &jet_IP3D, &b_jet_IP3D);
+  tree->SetBranchAddress("jet_SV1IP3D", &jet_SV1IP3D, &b_jet_SV1IP3D);
+  tree->SetBranchAddress("jet_MV1", &jet_MV1, &b_jet_MV1);
+  tree->SetBranchAddress("jet_MV2c00", &jet_MV2c00, &b_jet_MV2c00);
+  tree->SetBranchAddress("jet_MV2c20", &jet_MV2c20, &b_jet_MV2c20);
+  tree->SetBranchAddress("jet_MV2c20_is85", &jet_MV2c20_is85, &b_jet_MV2c20_is85);
+  tree->SetBranchAddress("jet_MV2c20_SF85", &jet_MV2c20_SF85, &b_jet_MV2c20_SF85);
+  tree->SetBranchAddress("jet_MV2c20_is77", &jet_MV2c20_is77, &b_jet_MV2c20_is77);
+  tree->SetBranchAddress("jet_MV2c20_SF77", &jet_MV2c20_SF77, &b_jet_MV2c20_SF77);
+  tree->SetBranchAddress("jet_MV2c20_is70", &jet_MV2c20_is70, &b_jet_MV2c20_is70);
+  tree->SetBranchAddress("jet_MV2c20_SF70", &jet_MV2c20_SF70, &b_jet_MV2c20_SF70);
+  tree->SetBranchAddress("jet_MV2c20_is60", &jet_MV2c20_is60, &b_jet_MV2c20_is60);
+  tree->SetBranchAddress("jet_MV2c20_SF60", &jet_MV2c20_SF60, &b_jet_MV2c20_SF60);
+  if(m_btagJets && !m_btagOP.empty() ) { this->SetBTagAddresses(tree); }
+  tree->SetBranchAddress("jet_GhostArea", &jet_GhostArea, &b_jet_GhostArea);
+  tree->SetBranchAddress("jet_ActiveArea", &jet_ActiveArea, &b_jet_ActiveArea);
+  tree->SetBranchAddress("jet_VoronoiArea", &jet_VoronoiArea, &b_jet_VoronoiArea);
+  tree->SetBranchAddress("jet_ActiveArea4vec_pt", &jet_ActiveArea4vec_pt, &b_jet_ActiveArea4vec_pt);
+  tree->SetBranchAddress("jet_ActiveArea4vec_eta", &jet_ActiveArea4vec_eta, &b_jet_ActiveArea4vec_eta);
+  tree->SetBranchAddress("jet_ActiveArea4vec_phi", &jet_ActiveArea4vec_phi, &b_jet_ActiveArea4vec_phi);
+  tree->SetBranchAddress("jet_ActiveArea4vec_m", &jet_ActiveArea4vec_m, &b_jet_ActiveArea4vec_m);
+  tree->SetBranchAddress("jet_ConeTruthLabelID", &jet_ConeTruthLabelID, &b_jet_ConeTruthLabelID);
+  tree->SetBranchAddress("jet_TruthCount", &jet_TruthCount, &b_jet_TruthCount);
+  tree->SetBranchAddress("jet_TruthLabelDeltaR_B", &jet_TruthLabelDeltaR_B, &b_jet_TruthLabelDeltaR_B);
+  tree->SetBranchAddress("jet_TruthLabelDeltaR_C", &jet_TruthLabelDeltaR_C, &b_jet_TruthLabelDeltaR_C);
+  tree->SetBranchAddress("jet_TruthLabelDeltaR_T", &jet_TruthLabelDeltaR_T, &b_jet_TruthLabelDeltaR_T);
+  tree->SetBranchAddress("jet_PartonTruthLabelID", &jet_PartonTruthLabelID, &b_jet_PartonTruthLabelID);
+  tree->SetBranchAddress("jet_GhostTruthAssociationFraction", &jet_GhostTruthAssociationFraction, &b_jet_GhostTruthAssociationFraction);
+  tree->SetBranchAddress("jet_truth_E", &jet_truth_E, &b_jet_truth_E);
+  tree->SetBranchAddress("jet_truth_pt", &jet_truth_pt, &b_jet_truth_pt);
+  tree->SetBranchAddress("jet_truth_phi", &jet_truth_phi, &b_jet_truth_phi);
+  tree->SetBranchAddress("jet_truth_eta", &jet_truth_eta, &b_jet_truth_eta);
+  tree->SetBranchAddress("jet_constitScaleEta", &jet_constitScaleEta, &b_jet_constitScaleEta);
+  tree->SetBranchAddress("jet_emScaleEta", &jet_emScaleEta, &b_jet_emScaleEta);
+  tree->SetBranchAddress("jet_mucorrected_pt", &jet_mucorrected_pt, &b_jet_mucorrected_pt);
+  tree->SetBranchAddress("jet_mucorrected_eta", &jet_mucorrected_eta, &b_jet_mucorrected_eta);
+  tree->SetBranchAddress("jet_mucorrected_phi", &jet_mucorrected_phi, &b_jet_mucorrected_phi);
+  tree->SetBranchAddress("jet_mucorrected_m", &jet_mucorrected_m, &b_jet_mucorrected_m);
+  tree->SetBranchAddress("nmuon", &nmuon, &b_nmuon);
+  tree->SetBranchAddress("muon_pt", &muon_pt, &b_muon_pt);
+  tree->SetBranchAddress("muon_phi", &muon_phi, &b_muon_phi);
+  tree->SetBranchAddress("muon_eta", &muon_eta, &b_muon_eta);
+  tree->SetBranchAddress("muon_m", &muon_m, &b_muon_m);
+  tree->SetBranchAddress("muon_effSF", &muon_effSF, &b_muon_effSF);
+}

--- a/Root/ZJetBalanceMiniTreeAnaSkeleton.cxx
+++ b/Root/ZJetBalanceMiniTreeAnaSkeleton.cxx
@@ -57,15 +57,8 @@ EL::StatusCode  ZJetBalanceMiniTreeAnaSkeleton :: configure ()
     return EL::StatusCode::FAILURE;
   }
   
-  if( m_btagJets ) {
-    if( m_btagOP != "85" && m_btagOP != "77" && m_btagOP != "70" && m_btagOP != "60" ) {
-      std::cout << "Invalid b-tag operating point " << m_btagOP << std::endl;
-      return EL::StatusCode::FAILURE;
-    }
-    std::cout << "BTagging using the " << m_btagOP << "% operating point" << std::endl;
-  }
-  
-  
+  //  m_XXX  = config->GetValue("XXX" , false );
+
   config->Print();
   Info("configure()", "ZJetBalanceMiniTreeAnaSkeleton Interface succesfully configured! \n");
   
@@ -100,6 +93,10 @@ EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: histInitialize ()
   // add your own histgrams
   m_h_ZM = this->book("ZM", "M_{Z} [GeV]", 60, 60, 120);
   
+  // pass all histograms instanted with the book function are passed
+  // to the worker through 
+  this->record( wk() );
+  
   Info("histInitialize()", "ends");
   return EL::StatusCode::SUCCESS;
 }
@@ -126,10 +123,6 @@ EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: initialize ()
     return EL::StatusCode::FAILURE;      
   }
   
-  
-  // pass all histograms instanted with the book function are passed
-  // to the worker through 
-  this->record( wk() );
   
   Info("initialize()", "Succesfully initialized! \n");
   return EL::StatusCode::SUCCESS;

--- a/Root/ZJetBalanceMiniTreeAnaSkeleton.cxx
+++ b/Root/ZJetBalanceMiniTreeAnaSkeleton.cxx
@@ -1,0 +1,176 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/Worker.h>
+#include <EventLoop/OutputStream.h>
+#include <AthContainers/ConstDataVector.h>
+
+#include <xAODTracking/VertexContainer.h>
+#include <xAODJet/JetContainer.h>
+#include <xAODEventInfo/EventInfo.h>
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+
+#include <TFile.h>
+#include <TKey.h>
+#include <TLorentzVector.h>
+#include <TEnv.h>
+#include <TSystem.h>
+
+#include <utility>      
+#include <iostream>
+#include <fstream>
+
+#include <stdlib.h>
+
+using namespace std;
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(ZJetBalanceMiniTreeAnaSkeleton)
+
+ZJetBalanceMiniTreeAnaSkeleton :: ZJetBalanceMiniTreeAnaSkeleton ()
+{
+  Info("ZJetBalanceMiniTreeAnaSkeleton()", "Calling constructor");
+}
+
+EL::StatusCode  ZJetBalanceMiniTreeAnaSkeleton :: configure ()
+{
+  Info("configure()", "called");
+  
+  // load basic configuration
+  // m_debug m_doPUreweighting m_lumiCalcFileNames m_PRWFileNames m_additional_weight m_btagJets m_btagOP
+  if (this->LoadBasicConfiguration()==EL::StatusCode::FAILURE) {
+    Error("configure()", "failed in LoadBasicConfiguration()");
+    return EL::StatusCode::FAILURE;
+  }
+  
+  
+  
+  //
+  // Read Input from .config file
+  //
+  m_configName = gSystem->ExpandPathName( m_configName.c_str() );
+  Info("configure()", "Configuing ZJetBalanceMiniTreeAnaSkeleton Interface. User configuration read from : %s \n", m_configName.c_str());
+  TEnv* config = new TEnv(m_configName.c_str());
+  if( !config ) {
+    Error("configure()", "Failed to read config file!");
+    Error("configure()", "config name : %s",m_configName.c_str());
+    return EL::StatusCode::FAILURE;
+  }
+  
+  if( m_btagJets ) {
+    if( m_btagOP != "85" && m_btagOP != "77" && m_btagOP != "70" && m_btagOP != "60" ) {
+      std::cout << "Invalid b-tag operating point " << m_btagOP << std::endl;
+      return EL::StatusCode::FAILURE;
+    }
+    std::cout << "BTagging using the " << m_btagOP << "% operating point" << std::endl;
+  }
+  
+  
+  config->Print();
+  Info("configure()", "ZJetBalanceMiniTreeAnaSkeleton Interface succesfully configured! \n");
+  
+  Info("configure()", "Ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: setupJob (EL::Job& job)
+{
+  Info("setupJob()", "called");
+  
+  Info("setupJob()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: histInitialize ()
+{
+  Info("histInitialize()", "called");
+  
+  // configuration from ENV file (note : histInistialize called before initialize)
+  if ( this->configure() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed to properly configure. Exiting." );
+    return EL::StatusCode::FAILURE;
+  }
+  
+  
+  this->InitializeCutflows();
+  
+  // add your own histgrams
+  m_h_ZM = this->book("ZM", "M_{Z} [GeV]", 60, 60, 120);
+  
+  Info("histInitialize()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: fileExecute ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: initialize ()
+{
+  Info("initialize()", "Calling initialize");
+  
+  m_isMC          =  false;
+  m_eventCounter  =  0;
+  mcChannelNumber = -1; // needs for isMC decision
+  
+  // Pileup RW Tool //
+  if (this->InitializePileupReweightingTool() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed in pileup RW tool initialization" );
+    return EL::StatusCode::FAILURE;      
+  }
+  
+  
+  // pass all histograms instanted with the book function are passed
+  // to the worker through 
+  this->record( wk() );
+  
+  Info("initialize()", "Succesfully initialized! \n");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: execute ()
+{
+  this->LoadMiniTree();
+  
+  double weight_final=1.0;
+  if (m_isMC) {
+    double pileup_reweighting_factor = GetPileupReweightingFactor();
+    weight_final = 
+      mcEventWeight*weight_xs*pileup_reweighting_factor*m_additional_weight;
+  }
+  
+  FillCutflowHistograms("Process NTuple", mcEventWeight, weight_final);
+  m_h_ZM->Fill(ZM, weight_final);
+  
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: postExecute ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: finalize ()
+{
+  std::cout << "Finialize!" << std::endl;
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTreeAnaSkeleton :: histFinalize ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+

--- a/Root/ZJetBalanceMiniTree_GenBalanceHistograms.cxx
+++ b/Root/ZJetBalanceMiniTree_GenBalanceHistograms.cxx
@@ -383,7 +383,7 @@ EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: execute ()
   FillFlavorHistograms((m_balance_hists_b[lead_jet_pt_bin])[lead_jet_eta_bin],
 		       (m_balance_hists_c[lead_jet_pt_bin])[lead_jet_eta_bin],
 		       (m_balance_hists_l[lead_jet_pt_bin])[lead_jet_eta_bin],
-		       lead_jet_truthLabel, lead_jet_phi, weight_final);    
+		       lead_jet_truthLabel, lead_jet_pt/pTRef1, weight_final);    
   
   return EL::StatusCode::SUCCESS;
 }

--- a/Root/ZJetBalanceMiniTree_GenBalanceHistograms.cxx
+++ b/Root/ZJetBalanceMiniTree_GenBalanceHistograms.cxx
@@ -1,0 +1,462 @@
+#include <EventLoop/Job.h>
+#include <EventLoop/Worker.h>
+#include <EventLoop/OutputStream.h>
+#include <AthContainers/ConstDataVector.h>
+
+#include <xAODTracking/VertexContainer.h>
+#include <xAODJet/JetContainer.h>
+#include <xAODEventInfo/EventInfo.h>
+#include <ZJetBalance/ZJetBalanceMiniTree_GenBalanceHistograms.h>
+#include <xAODAnaHelpers/HelperFunctions.h>
+#include <xAODAnaHelpers/tools/ReturnCheck.h>
+
+#include <TFile.h>
+#include <TKey.h>
+#include <TLorentzVector.h>
+#include <TEnv.h>
+#include <TSystem.h>
+
+#include <utility>      
+#include <iostream>
+#include <fstream>
+
+#include <stdlib.h>
+
+using namespace std;
+
+// this is needed to distribute the algorithm to the workers
+ClassImp(ZJetBalanceMiniTree_GenBalanceHistograms)
+
+ZJetBalanceMiniTree_GenBalanceHistograms :: ZJetBalanceMiniTree_GenBalanceHistograms ()
+{
+  Info("ZJetBalanceMiniTree_GenBalanceHistograms()", "Calling constructor");
+}
+
+EL::StatusCode  ZJetBalanceMiniTree_GenBalanceHistograms :: configure ()
+{
+  Info("configure()", "called");
+  
+  // load basic configuration
+  // m_debug m_doPUreweighting m_lumiCalcFileNames m_PRWFileNames m_additional_weight m_btagJets m_btagOP
+  if (this->LoadBasicConfiguration()==EL::StatusCode::FAILURE) {
+    Error("configure()", "failed in LoadBasicConfiguration()");
+    return EL::StatusCode::FAILURE;
+  }
+  
+  
+  
+  //
+  // Read Input from .config file
+  //
+  m_configName = gSystem->ExpandPathName( m_configName.c_str() );
+  Info("configure()", "Configuing ZJetBalanceMiniTree_GenBalanceHistograms Interface. User configuration read from : %s \n", m_configName.c_str());
+  TEnv* config = new TEnv(m_configName.c_str());
+  if( !config ) {
+    Error("configure()", "Failed to read config file!");
+    Error("configure()", "config name : %s",m_configName.c_str());
+    return EL::StatusCode::FAILURE;
+  }
+  
+  TString pT_binning_str     = config->GetValue("pT_binning", "20,25,30,35,45,60,80,110,160,210,260,310,500");
+  TString eta_binning_str    = config->GetValue("eta_binning", "-4.5,-3.2,-2.5,-1.0,0,1.0,2.5,3.2,4.5");
+  m_nBinsXForResponseHist    = config->GetValue("nBinsXForResponseHist", 50.);
+  m_maxXForResponseHist      = config->GetValue("maxXForResponseHist", 5.0);
+  m_minXForResponseHist      = config->GetValue("minXForResponseHist", 0.0);
+  m_cutDPhiZJet              = config->GetValue("cutDPhiZJet", 2.8);
+  m_ZMassWindow              = config->GetValue("ZMassWindow", 15);
+  m_fillMuonBefore           = config->GetValue("FillMuonBefore", false);
+
+  // create object before configuration
+  m_pT_binning = new Double_t[BUFSIZ];
+  m_eta_binning = new Double_t[BUFSIZ];
+  
+  
+  DecodeBinning(pT_binning_str, m_pT_binning, m_n_pT_binning);
+  Info("configure()", "DecodeBinning() gives for pT  : nBins=%d, first=%.1f last=%.1f", m_n_pT_binning, m_pT_binning[0], m_pT_binning[m_n_pT_binning]);
+  DecodeBinning(eta_binning_str, m_eta_binning, m_n_eta_binning);
+  Info("configure()", "DecodeBinning() gives for eta : nBins=%d, first=%.1f last=%.1f", m_n_eta_binning, m_eta_binning[0], m_eta_binning[m_n_eta_binning]);
+  
+  config->Print();
+  Info("configure()", "ZJetBalanceMiniTree_GenBalanceHistograms Interface succesfully configured! \n");
+  
+  Info("configure()", "Ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: setupJob (EL::Job& job)
+{
+  Info("setupJob()", "called");
+  
+  Info("setupJob()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: histInitialize ()
+{
+  Info("histInitialize()", "called");
+  
+  // configuration from ENV file (note : histInistialize called before initialize)
+  if ( this->configure() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed to properly configure. Exiting." );
+    return EL::StatusCode::FAILURE;
+  }
+  
+  // list of the histograms
+  TH1::SetDefaultSumw2();
+  
+  this->InitializeCutflows();
+  
+  // add your own histgrams
+  m_h_RunNumber = book("RunNumber", "Run Number", 1000, 271000.5, 272000.5);
+  m_h_muon1_pT = book("muon1_pT", "#mu_{1} p_{T} [GeV]", 120, 0, 120);
+  m_h_muon2_pT = book("muon2_pT", "#mu_{2} p_{T} [GeV]", 120, 0, 120);
+  m_h_muon1_eta = book("muon1_eta", "#mu_{1} #eta", 60, -3.0, 3.0);
+  m_h_muon2_eta = book("muon2_eta", "#mu_{2} #eta", 60, -3.0, 3.0);
+  m_h_muon1_phi = book("muon1_phi", "#mu_{1} #phi", 64, -TMath::Pi(), TMath::Pi());
+  m_h_muon2_phi = book("muon2_phi", "#mu_{2} #phi", 64, -TMath::Pi(), TMath::Pi());
+  // plots of Z itself
+  m_h_ZpT   = book("ZpT",   "Z p_{T} [GeV]",  120,  0,    240);
+  m_h_Zeta  = book("Zeta",  "Z #eta",         60,  -3.0, 3.0);
+  m_h_Zphi  = book("Zphi",  "Z #phi",         64, -TMath::Pi(), TMath::Pi());
+  m_h_ZM    = book("ZM",    "m_{Z} [GeV]",    60, 60, 120);
+  // Jet Plots
+  // before cuts
+  m_h_nJets_beforecut = book("nJets_beforecut", "N Jets Before Cuts", 10, -0.5, 9.5);
+  m_h_jet_eta_beforecut = book("jet_eta_beforecut", "",   64, -3.2, 3.2);
+  m_h_jet_pt_beforecut  = book("jet_pt_beforecut", "",    30,    0, 300);
+  m_h_jet_eta_beforecut_b = book("jet_eta_beforecut_b", "",   64, -3.2, 3.2);
+  m_h_jet_pt_beforecut_b  = book("jet_pt_beforecut_b", "",    30,    0, 300);
+  m_h_jet_eta_beforecut_c = book("jet_eta_beforecut_c", "",   64, -3.2, 3.2);
+  m_h_jet_pt_beforecut_c  = book("jet_pt_beforecut_c", "",    30,    0, 300);
+  m_h_jet_eta_beforecut_l = book("jet_eta_beforecut_l", "",   64, -3.2, 3.2);
+  m_h_jet_pt_beforecut_l  = book("jet_pt_beforecut_l", "",    30,    0, 300);
+  // after cuts
+  m_h_nJets = book("nJets",           "N Jets", 10, -0.5, 9.5);
+  m_h_jet_phi   = book("jet_phi", "jet_{1} #phi",   64, -TMath::Pi(), TMath::Pi());
+  m_h_jet_phi_b = book("jet_phi_b", "jet_{1} #phi MC truth b",   64, -TMath::Pi(), TMath::Pi());
+  m_h_jet_phi_c = book("jet_phi_c", "jet_{1} #phi MC truth c",   64, -TMath::Pi(), TMath::Pi());
+  m_h_jet_phi_l = book("jet_phi_l", "jet_{1} #phi MC truth l",   64, -TMath::Pi(), TMath::Pi());
+  m_h_jet_eta = book("jet_eta", "jet^{1} #eta", 50, m_eta_binning[0], m_eta_binning[m_n_eta_binning]);
+  m_h_jet_eta_b = book("jet_eta_b", "jet^{1} #eta MC truth b", 50, m_eta_binning[0], m_eta_binning[m_n_eta_binning]);
+  m_h_jet_eta_c = book("jet_eta_c", "jet^{1} #eta MC truth c", 50, m_eta_binning[0], m_eta_binning[m_n_eta_binning]);
+  m_h_jet_eta_l = book("jet_eta_l", "jet^{1} p_{T} MC truth l", 50, m_eta_binning[0], m_eta_binning[m_n_eta_binning]);
+  m_h_jet_pt  = book("jet_pt",  "jet^{1} p_{T}", 50, 0, 300.);
+  m_h_jet_pt_b  = book("jet_pt_b",  "jet^{1} p_{T} MC truth b", 50, 0, 300.);
+  m_h_jet_pt_c  = book("jet_pt_c",  "jet^{1} p_{T} MC truth c", 50, 0, 300.);
+  m_h_jet_pt_l  = book("jet_pt_l",  "jet^{1} #eta MC truth l", 50, 0, 300.);
+
+  m_h_jet_pt_bin = new TH2F("jet_pt_bin", "", 100, 0, 500, m_n_pT_binning, -0.5, -0.5+m_n_pT_binning); // validation purpose
+  wk()->addOutput( m_h_jet_pt_bin );
+  
+  m_h_pt_binning_info = book("pt_binning_info", "", m_n_pT_binning, m_pT_binning);
+  m_h_eta_binning_info = book("eta_binning_info", "", m_n_eta_binning, m_eta_binning);
+  
+  // Z-Jet relationship
+  m_h_Z_jet_dPhi = book("Z_jet_dPhi", "", 100, -TMath::Pi(), TMath::Pi());
+  m_h_Z_jet_dEta = book("Z_jet_dEta", "", 64, -3.2, 3.2);
+  // balance hist instanted elsewhere as uses custom/configurable binning
+  // weights
+  m_h_prwfactor  = book("prwfactor", "Pile-up Weight", 100, 0, 3.0);
+  m_h_muonTrigFactor =  book("muonTrigFactor", "Muon Trigger Weight", 100, 0.0, 2.0);
+  m_h_muon1EffFactor =  book("muon1EffFactor", "muon_{1} Efficiency SF", 100, 0.0, 2.0);
+  m_h_muon2EffFactor =  book("muon2EffFactor", "muon_{2} Efficiency SF", 100, 0.0, 2.0);    
+  
+  m_h_averageInteractionsPerCrossing = book("averageInteractionsPerCrossing", "", 50, 0, 50.);
+  
+  // before cuts muon plots
+  if( m_fillMuonBefore ) {
+    m_h_muon1_pT_beforecut = book("muon1_pT_beforecut", "#mu_{1} p_{T} [GeV]", 120, 0, 120);
+    m_h_muon2_pT_beforecut = book("muon2_pT_beforecut", "#mu_{2} p_{T} [GeV]", 120, 0, 120);
+    m_h_muon1_eta_beforecut = book("muon1_eta_beforecut", "#mu_{1} #eta", 60, -3.0, 3.0);
+    m_h_muon2_eta_beforecut = book("muon2_eta_beforecut", "#mu_{2} #eta", 60, -3.0, 3.0);
+    m_h_muon1_phi_beforecut = book("muon1_phi_beforecut", "#mu_{1} #phi", 64, -TMath::Pi(), TMath::Pi());
+    m_h_muon2_phi_beforecut = book("muon2_phi_beforecut", "#mu_{2} #phi", 64, -TMath::Pi(), TMath::Pi());
+  }
+  
+  // additinoal histograms according to configuration parameters
+  for (int iPtBin=1; iPtBin<m_n_pT_binning+1; iPtBin++) {
+    std::vector<TH1F*> tmp_hist_container;
+    std::vector<TH1F*> tmp_hist_container_b;
+    std::vector<TH1F*> tmp_hist_container_c;
+    std::vector<TH1F*> tmp_hist_container_l;
+    for (int iEtaBin=1; iEtaBin<m_n_eta_binning+1; iEtaBin++) {
+      Info("Initialize()", "%s", Form("DB_RefEtaBin%d_PtBin%d", iEtaBin, iPtBin));
+      TH1F* h = new TH1F(Form("DB_RefEtaBin%d_PtBin%d", iEtaBin, iPtBin), 
+			 Form("%.1f<p_{T}<%.1f, %.1f<#eta<%.1f", 
+			      m_pT_binning[iPtBin-1], m_pT_binning[iPtBin],
+			      m_eta_binning[iEtaBin-1], m_eta_binning[iEtaBin]
+			      ), 
+			 m_nBinsXForResponseHist, m_minXForResponseHist, m_maxXForResponseHist);
+      TH1F* h_b = new TH1F(Form("DB_RefEtaBin%d_PtBin%d_b", iEtaBin, iPtBin), 
+			   Form("%.1f<p_{T}<%.1f, %.1f<#eta<%.1f", 
+				m_pT_binning[iPtBin-1], m_pT_binning[iPtBin],
+				m_eta_binning[iEtaBin-1], m_eta_binning[iEtaBin]
+				), 
+			   m_nBinsXForResponseHist, m_minXForResponseHist, m_maxXForResponseHist);
+      TH1F* h_c = new TH1F(Form("DB_RefEtaBin%d_PtBin%d_c", iEtaBin, iPtBin), 
+			   Form("%.1f<p_{T}<%.1f, %.1f<#eta<%.1f", 
+				m_pT_binning[iPtBin-1], m_pT_binning[iPtBin],
+				m_eta_binning[iEtaBin-1], m_eta_binning[iEtaBin]
+			      ), 
+			   m_nBinsXForResponseHist, m_minXForResponseHist, m_maxXForResponseHist);
+      TH1F* h_l = new TH1F(Form("DB_RefEtaBin%d_PtBin%d_l", iEtaBin, iPtBin), 
+			   Form("%.1f<p_{T}<%.1f, %.1f<#eta<%.1f", 
+				m_pT_binning[iPtBin-1], m_pT_binning[iPtBin],
+				m_eta_binning[iEtaBin-1], m_eta_binning[iEtaBin]
+				), 
+			   m_nBinsXForResponseHist, m_minXForResponseHist, m_maxXForResponseHist);
+      tmp_hist_container.push_back(h);
+      tmp_hist_container_b.push_back(h_b);
+      tmp_hist_container_c.push_back(h_c);
+      tmp_hist_container_l.push_back(h_l);
+      wk()->addOutput( h );
+      wk()->addOutput( h_b );
+      wk()->addOutput( h_c );
+      wk()->addOutput( h_l );
+    }
+    
+    m_balance_hists.push_back(tmp_hist_container);
+    m_balance_hists_b.push_back(tmp_hist_container_b);
+    m_balance_hists_c.push_back(tmp_hist_container_c);
+    m_balance_hists_l.push_back(tmp_hist_container_l);
+  }  
+  
+  // pass all histograms instanted with the book function are passed
+  // to the worker through 
+  this->record( wk() );
+
+  Info("histInitialize()", "ends");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: fileExecute ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: initialize ()
+{
+  Info("initialize()", "Calling initialize");
+  
+  m_isMC          =  false;
+  m_eventCounter  =  0;
+  mcChannelNumber = -1; // needs for isMC decision
+  
+  // Pileup RW Tool //
+  if (this->InitializePileupReweightingTool() == EL::StatusCode::FAILURE ) {
+    Error("initialize()", "Failed in pileup RW tool initialization" );
+    return EL::StatusCode::FAILURE;      
+  }
+  
+  Info("initialize()", "Succesfully initialized! \n");
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: execute ()
+{
+  this->LoadMiniTree();
+  
+  double weight_final=1.0;
+  if (m_isMC) {
+    double pileup_reweighting_factor = GetPileupReweightingFactor();
+    weight_final = 
+      mcEventWeight*weight_xs*pileup_reweighting_factor*m_additional_weight;
+    // trigger weight: 0 is nominal, rest are systematics +,- 1 sigma for each
+    m_h_muonTrigFactor->Fill( weight_muon_trig->at(0) );
+    weight_final *= weight_muon_trig->at(0);
+    // muon efficiency scale factors: 0 is nominal, rest are systematics +,- 1 sigma for each
+    m_h_muon1EffFactor->Fill( muon_effSF->at(0)[0] );
+    m_h_muon2EffFactor->Fill( muon_effSF->at(1)[0] );
+    weight_final *= muon_effSF->at(0)[0] * muon_effSF->at(1)[0];
+  }
+  
+  FillCutflowHistograms("Process NTuple", mcEventWeight, weight_final);
+
+  if(m_debug) Info("execute()", "Processing Event @ RunNumber=%10d, EventNumber=%d", runNumber, eventNumber);
+  ++m_eventCounter;
+  if (m_eventCounter%10000==0) {
+    Info("execute()", "%10d th event is been processed.", m_eventCounter);
+  }
+
+  m_h_RunNumber->Fill(runNumber, weight_final);
+  m_h_averageInteractionsPerCrossing->Fill(averageInteractionsPerCrossing, weight_final); // for validation
+
+  // for valiadtion
+  int nJetsBeforeCut = 0;
+  for (int iJet=0, nJets=jet_pt->size(); iJet<nJets; iJet++) {
+    const float& pt  = jet_pt->at(iJet);
+    const float& eta = jet_eta->at(iJet);
+    const int& truthLabel = m_isMC ? jet_ConeTruthLabelID->at(iJet) : -1;
+    
+    if ( pt < 30. ) continue;
+    nJetsBeforeCut++;
+    
+    m_h_jet_eta_beforecut->Fill(eta, weight_final);
+    m_h_jet_pt_beforecut->Fill(pt, weight_final);
+    FillFlavorHistograms(m_h_jet_pt_beforecut_b, m_h_jet_pt_beforecut_c, m_h_jet_pt_beforecut_l, 
+			 truthLabel, pt, weight_final);
+    FillFlavorHistograms(m_h_jet_eta_beforecut_b, m_h_jet_eta_beforecut_c, m_h_jet_eta_beforecut_l,
+			 truthLabel, eta, weight_final);
+  }
+  m_h_nJets_beforecut->Fill(nJetsBeforeCut, weight_final);
+
+  // muon before cut
+  if( m_fillMuonBefore ) {
+    m_h_muon1_pT_beforecut->Fill ( muon_pt ->at(0), weight_final );
+    m_h_muon1_eta_beforecut->Fill( muon_eta->at(0), weight_final );
+    m_h_muon1_phi_beforecut->Fill( muon_phi->at(0), weight_final );
+    m_h_muon2_pT_beforecut->Fill ( muon_pt ->at(1), weight_final );
+    m_h_muon2_eta_beforecut->Fill( muon_eta->at(1), weight_final );
+    m_h_muon2_phi_beforecut->Fill( muon_phi->at(1), weight_final );
+  }
+
+  // selection criteria need to be applied
+  if (TMath::Abs(ZM-91)>m_ZMassWindow)      { return EL::StatusCode::SUCCESS; }
+  FillCutflowHistograms("m_{Z} Window", mcEventWeight, weight_final);
+
+  if (TMath::Abs(dPhiZJet1)<m_cutDPhiZJet)  { return EL::StatusCode::SUCCESS; }
+  FillCutflowHistograms("#Delta#phi(Z,jet)", mcEventWeight, weight_final);
+
+  // 
+  const float& lead_jet_pt      = jet_pt->at(0);
+  const float& lead_jet_eta     = jet_eta->at(0);
+  const float& lead_jet_phi     = jet_phi->at(0);
+  const int&   lead_jet_truthLabel = m_isMC ? jet_ConeTruthLabelID->at(0) : -1;
+  const int    lead_jet_pt_bin  = GetPtBin(pTRef1);
+  const int    lead_jet_eta_bin = GetEtaBin(lead_jet_eta);
+
+  //Info("execute()", "lead_jet_eta=%.1f (%d) lead_jet_pt=%.1f (%d)",
+  //lead_jet_eta, lead_jet_eta_bin, lead_jet_pt, lead_jet_pt_bin);
+
+  if (lead_jet_eta_bin==-1) {return EL::StatusCode::SUCCESS;} // out of eta range (defined as binning)
+  FillCutflowHistograms("jet_{1} #eta", mcEventWeight, weight_final);
+
+  if (jet_pt->size()>1) { if (jet_pt->at(1)>pTRef1*0.2) {return EL::StatusCode::SUCCESS;} } // event with second jet is vetoed
+  FillCutflowHistograms("jet_{2} p_{T}", mcEventWeight, weight_final);
+
+  if( m_btagJets ) {
+    // b-tag if asked for
+    if( !jet_isBTag->at(0) ) { return EL::StatusCode::SUCCESS; }
+    FillCutflowHistograms("jet_{1} b-tagged", mcEventWeight, weight_final);
+    // apply b-tagging weight
+    weight_final *= jet_SFBTag->at(0)[0]; // other weights are for systematics
+    //Info("execute()", "jet_SFBTag->at(0)[0]=%f \n", jet_SFBTag->at(0)[0]);
+    
+    FillCutflowHistograms("jet_{1} b-tag SF", mcEventWeight, weight_final);
+  }
+
+  // muon plots
+  m_h_muon1_pT->Fill ( muon_pt ->at(0), weight_final );
+  m_h_muon1_eta->Fill( muon_eta->at(0), weight_final );
+  m_h_muon1_phi->Fill( muon_phi->at(0), weight_final );
+  m_h_muon2_pT->Fill ( muon_pt ->at(1), weight_final );
+  m_h_muon2_eta->Fill( muon_eta->at(1), weight_final );
+  m_h_muon2_phi->Fill( muon_phi->at(1), weight_final );
+  // plots of Z itself
+  m_h_ZpT->Fill(ZpT, weight_final);
+  m_h_Zeta->Fill(Zeta, weight_final);
+  m_h_Zphi->Fill(Zphi, weight_final);
+  m_h_ZM->Fill(ZM, weight_final);
+  // jet plots after cuts
+  m_h_nJets->Fill(njets, weight_final);
+  m_h_jet_pt_bin->Fill(lead_jet_pt, lead_jet_pt_bin, weight_final);
+  m_h_jet_eta->Fill(lead_jet_eta, weight_final);
+  m_h_jet_pt->Fill(lead_jet_pt, weight_final);
+  m_h_jet_phi->Fill(lead_jet_phi, weight_final);
+  FillFlavorHistograms(m_h_jet_pt_b, m_h_jet_pt_c, m_h_jet_pt_l, 
+		       lead_jet_truthLabel, lead_jet_pt, weight_final);
+  FillFlavorHistograms(m_h_jet_eta_b, m_h_jet_eta_c, m_h_jet_eta_l, 
+		       lead_jet_truthLabel, lead_jet_eta, weight_final);
+  FillFlavorHistograms(m_h_jet_phi_b, m_h_jet_phi_c, m_h_jet_phi_l, 
+		       lead_jet_truthLabel, lead_jet_phi, weight_final);
+  // Z-Jet relationship
+  m_h_Z_jet_dPhi->Fill(dPhiZJet1, weight_final);
+  m_h_Z_jet_dEta->Fill(dEtaZJet1, weight_final);
+  (m_balance_hists[lead_jet_pt_bin])[lead_jet_eta_bin]->Fill(lead_jet_pt/pTRef1, weight_final);
+  FillFlavorHistograms((m_balance_hists_b[lead_jet_pt_bin])[lead_jet_eta_bin],
+		       (m_balance_hists_c[lead_jet_pt_bin])[lead_jet_eta_bin],
+		       (m_balance_hists_l[lead_jet_pt_bin])[lead_jet_eta_bin],
+		       lead_jet_truthLabel, lead_jet_phi, weight_final);    
+  
+  return EL::StatusCode::SUCCESS;
+}
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: postExecute ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: finalize ()
+{
+  std::cout << "Finialize!" << std::endl;
+  return EL::StatusCode::SUCCESS;
+}
+
+
+
+EL::StatusCode ZJetBalanceMiniTree_GenBalanceHistograms :: histFinalize ()
+{
+  return EL::StatusCode::SUCCESS;
+}
+
+void ZJetBalanceMiniTree_GenBalanceHistograms::DecodeBinning(TString binning_str, Double_t* binning_array, Int_t& n_binning)
+{
+  TString tok;
+  Ssiz_t  from = 0;
+  binning_str.ReplaceAll(" ", "");
+  int iArrayIndex=0;
+  while (binning_str.Tokenize(tok, from, ",")) {  
+    const double x = strtod(tok.Data(), NULL);
+    binning_array[iArrayIndex]=x;
+    iArrayIndex++;
+  }
+  n_binning=iArrayIndex-1;
+  
+  return;
+}
+
+int ZJetBalanceMiniTree_GenBalanceHistograms::GetPtBin(const double& _pt)
+{
+  int rc=0;
+  for (; rc<m_n_pT_binning-1; rc++) {
+    if (_pt<m_pT_binning[rc+1]) {break;}
+  }
+  return rc;
+}
+
+int ZJetBalanceMiniTree_GenBalanceHistograms::GetEtaBin(const double& _eta)
+{
+  int rc=-1;
+  for (int iBin=0; iBin<m_n_eta_binning; iBin++) {
+    if (m_eta_binning[iBin]<_eta && _eta<m_eta_binning[iBin+1]) {
+      rc = iBin;
+      break;
+    }
+  }
+  return rc;
+}
+
+void ZJetBalanceMiniTree_GenBalanceHistograms::FillFlavorHistograms(TH1F* h_b, TH1F* h_c, TH1F* h_l, const int& truthLabel, const float& value, const float& weight)
+{
+  switch (TMath::Abs(truthLabel)) {
+  case 5:
+    h_b->Fill(value, weight);
+    break;
+  case 4:
+    h_c->Fill(value, weight);
+    break;
+  default:
+    h_l->Fill(value, weight);
+    break;
+  }
+}

--- a/ZJetBalance/ZJetBalanceMiniTreeAnaBase.h
+++ b/ZJetBalance/ZJetBalanceMiniTreeAnaBase.h
@@ -1,0 +1,351 @@
+#ifndef ZJetBalanceMiniTreeAnaBase_H
+#define ZJetBalanceMiniTreeAnaBase_H
+
+#include <EventLoop/StatusCode.h>
+#include <EventLoop/Algorithm.h>
+#include <EventLoop/Worker.h>
+
+//algorithm wrapper
+#include <xAODAnaHelpers/Algorithm.h>
+#include "PileupReweighting/PileupReweightingTool.h"
+
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TTree.h>
+#include <TBranch.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+class ZJetBalanceMiniTreeAnaBase : public xAH::Algorithm
+{
+ protected:
+  // float cutValue;
+  int m_eventCounter;  //!
+  std::string m_histPrefix;  //!
+  bool m_isMC;
+  
+  bool m_debug; //! set verbose mode
+  bool m_doPUreweighting; //! configurable parameter
+  std::string m_lumiCalcFileNames; //! configurable parameter
+  std::string m_PRWFileNames; //! configurable parameter
+  bool m_btagJets;      //! configurable parameter
+  double m_additional_weight;   //! configurable parameter
+  std::string m_btagOP; //! configurable parameter
+  
+  // tools 
+  CP::PileupReweightingTool* m_pileuptool; //!
+  
+  // histograms
+  TH1F* m_h_cutflow; //!
+  TH1F* m_h_cutflow_weighted; //!
+  TH1F* m_h_cutflow_weighted_final; //!
+  
+ public: 
+  // this is a standard constructor
+  ZJetBalanceMiniTreeAnaBase();
+ 
+  virtual EL::StatusCode configure (); 
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  EL::StatusCode changeInput (bool firstFile);
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+  
+ public:
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(ZJetBalanceMiniTreeAnaBase, 1);
+  
+ protected:
+  // common functions to be used
+  std::vector< TH1* > m_allHists; //!
+
+  // histogram functions
+  TH1F* book(std::string title,
+      std::string xlabel, int xbins, double xlow, double xhigh);
+
+  TH2F* book(std::string title,
+      std::string xlabel, int xbins, double xlow, double xhigh,
+      std::string xyabel, int ybins, double ylow, double yhigh);
+  //// Variable Binned Histograms ////
+  TH1F* book(std::string title,
+      std::string xlabel, int xbins, const Double_t* xbinsArr);
+
+  TH2F* book(std::string title,
+      std::string xlabel, int xbins, const Double_t* xbinsArr,
+      std::string ylabel, int ybins, double ylow, double yhigh);
+  TH2F* book(std::string title,
+      std::string xyabel, int xbins, double xlow, double xhigh,
+      std::string ylabel, int ybins, const Double_t* ybinsArr);
+  TH2F* book(std::string title,
+      std::string xyabel, int xbins, const Double_t* xbinsArr,
+      std::string ylabel, int ybins, const Double_t* ybinsArr);
+  
+  // Record all histograms from m_allHists to the worker
+  void record(EL::Worker* wk);
+  
+  // Turn on Sumw2 for the histogram
+  void Sumw2(TH1* hist, bool flag=true);
+
+  // Push the new histogram to m_allHists
+  void record(TH1* hist);
+
+  // Set the xlabel
+  void SetLabel(TH1* hist, std::string xlabel);
+  
+  // Set the xlabel, ylabel
+  void SetLabel(TH1* hist, std::string xlabel, std::string ylabel);
+  
+  // Return Cutflow pointer
+  std::pair<TH1F*, TH1F*> ReturnCutflowPointers();
+  
+  // initialize cutflow (please call it in histInitialize())
+  void InitializeCutflows();
+  
+  // fill three different types of histograms
+  void FillCutflowHistograms(const std::string& label, const double& xAHWeight, const double& weightFinal);
+  
+  // initialize pileup reweighting tool (please call it in initialize())
+  EL::StatusCode InitializePileupReweightingTool();
+  
+  // get pileup reweight handled with 
+  double GetPileupReweightingFactor(); 
+  
+  // load mini tree please call this in initialize 
+  void LoadMiniTree();
+  
+  // load basic configuration
+  EL::StatusCode LoadBasicConfiguration();
+  
+ protected:
+  // commmon functin related to TTree access
+  void            SetBTagAddresses(TTree* tree);  
+  void            InitTree(TTree* tree);
+  // copied from MakeClass function and add //! for all the variables
+  // Declaration of leaf types
+
+  // Declaration of leaf types
+  Int_t           runNumber; //!
+  Int_t           eventNumber; //!
+  Int_t           mcEventNumber; //!
+  Int_t           mcChannelNumber; //!
+  Float_t         mcEventWeight; //!
+  Float_t         weight_pileup; //!
+  Int_t           NPV; //!
+  Float_t         actualInteractionsPerCrossing; //!
+  Float_t         averageInteractionsPerCrossing; //!
+  Int_t           lumiBlock; //!
+  Double_t        rhoEM; //!
+  Int_t           pdgId1; //!
+  Int_t           pdgId2; //!
+  Int_t           pdfId1; //!
+  Int_t           pdfId2; //!
+  Float_t         x1; //!
+  Float_t         x2; //!
+  Float_t         xf1; //!
+  Float_t         xf2; //!
+  Float_t         ZpT; //!
+  Float_t         Zeta; //!
+  Float_t         Zphi; //!
+  Float_t         ZM; //!
+  Float_t         dPhiZJet1; //!
+  Float_t         dEtaZJet1; //!
+  Float_t         pTRef1; //!
+  Float_t         dPhiZJet2; //!
+  Float_t         dEtaZJet2; //!
+  Float_t         pTRef2; //!
+  Float_t         jetDPhi; //!
+  Float_t         jetDEta; //!
+  Float_t         jetPtRatio; //!
+  Float_t         weight; //!
+  Float_t         weight_xs; //!
+  Float_t         weight_prescale; //!
+  std::vector<double>  *weight_muon_trig; //!
+  Int_t           njets; //!
+  std::vector<float>   *jet_E; //!
+  std::vector<float>   *jet_pt; //!
+  std::vector<float>   *jet_phi; //!
+  std::vector<float>   *jet_eta; //!
+  std::vector<float>   *jet_rapidity; //!
+  std::vector<float>   *jet_HECFrac; //!
+  std::vector<float>   *jet_EMFrac; //!
+  std::vector<float>   *jet_CentroidR; //!
+  std::vector<float>   *jet_FracSamplingMax; //!
+  std::vector<float>   *jet_FracSamplingMaxIndex; //!
+  std::vector<float>   *jet_LowEtConstituentsFrac; //!
+  std::vector<float>   *jet_GhostMuonSegmentCount; //!
+  std::vector<float>   *jet_Width; //!
+  std::vector<int>     *jet_NumTrkPt1000PV; //!
+  std::vector<float>   *jet_SumPtTrkPt1000PV; //!
+  std::vector<float>   *jet_TrackWidthPt1000PV; //!
+  std::vector<int>     *jet_NumTrkPt500PV; //!
+  std::vector<float>   *jet_SumPtTrkPt500PV; //!
+  std::vector<float>   *jet_TrackWidthPt500PV; //!
+  std::vector<float>   *jet_JVFPV; //!
+  std::vector<float>   *jet_Jvt; //!
+  std::vector<float>   *jet_JvtJvfcorr; //!
+  std::vector<float>   *jet_JvtRpt; //!
+  std::vector<float>   *jet_SV0; //!
+  std::vector<float>   *jet_SV1; //!
+  std::vector<float>   *jet_IP3D; //!
+  std::vector<float>   *jet_SV1IP3D; //!
+  std::vector<float>   *jet_MV1; //!
+  std::vector<float>   *jet_MV2c00; //!
+  std::vector<float>   *jet_MV2c20; //!
+  std::vector<int>     *jet_MV2c20_is85; //!
+  std::vector<std::vector<float> > *jet_MV2c20_SF85; //!
+  std::vector<int>     *jet_MV2c20_is77; //!
+  std::vector<std::vector<float> > *jet_MV2c20_SF77; //!
+  std::vector<int>     *jet_MV2c20_is70; //!
+  std::vector<std::vector<float> > *jet_MV2c20_SF70; //!
+  std::vector<int>     *jet_MV2c20_is60; //!
+  std::vector<std::vector<float> > *jet_MV2c20_SF60; //!
+  std::vector<int>     *jet_isBTag; //!
+  std::vector<std::vector<float> > *jet_SFBTag; //!
+  std::vector<float>   *jet_GhostArea; //!
+  std::vector<float>   *jet_ActiveArea; //!
+  std::vector<float>   *jet_VoronoiArea; //!
+  std::vector<float>   *jet_ActiveArea4vec_pt; //!
+  std::vector<float>   *jet_ActiveArea4vec_eta; //!
+  std::vector<float>   *jet_ActiveArea4vec_phi; //!
+  std::vector<float>   *jet_ActiveArea4vec_m; //!
+  std::vector<int>     *jet_ConeTruthLabelID; //!
+  std::vector<int>     *jet_TruthCount; //!
+  std::vector<float>   *jet_TruthLabelDeltaR_B; //!
+  std::vector<float>   *jet_TruthLabelDeltaR_C; //!
+  std::vector<float>   *jet_TruthLabelDeltaR_T; //!
+  std::vector<int>     *jet_PartonTruthLabelID; //!
+  std::vector<float>   *jet_GhostTruthAssociationFraction; //!
+  std::vector<float>   *jet_truth_E; //!
+  std::vector<float>   *jet_truth_pt; //!
+  std::vector<float>   *jet_truth_phi; //!
+  std::vector<float>   *jet_truth_eta; //!
+  std::vector<float>   *jet_constitScaleEta; //!
+  std::vector<float>   *jet_emScaleEta; //!
+  std::vector<float>   *jet_mucorrected_pt; //!
+  std::vector<float>   *jet_mucorrected_eta; //!
+  std::vector<float>   *jet_mucorrected_phi; //!
+  std::vector<float>   *jet_mucorrected_m; //!
+  std::vector<float>   *muon_pt; //!
+  std::vector<float>   *muon_eta; //!
+  std::vector<float>   *muon_phi; //!
+  std::vector<float>   *muon_m; //!
+  std::vector< std::vector<double> >  *muon_effSF; //!
+  Int_t           nmuon; //!
+
+  // List of branches
+  TBranch        *b_runNumber;   //!
+  TBranch        *b_eventNumber;   //!
+  TBranch        *b_mcEventNumber;   //!
+  TBranch        *b_mcChannelNumber;   //!
+  TBranch        *b_mcEventWeight;   //!
+  TBranch        *b_weight_pileup;   //!
+  TBranch        *b_NPV;   //!
+  TBranch        *b_actualInteractionsPerCrossing;   //!
+  TBranch        *b_averageInteractionsPerCrossing;   //!
+  TBranch        *b_lumiBlock;   //!
+  TBranch        *b_rhoEM;   //!
+  TBranch        *b_pdgId1;   //!
+  TBranch        *b_pdgId2;   //!
+  TBranch        *b_pdfId1;   //!
+  TBranch        *b_pdfId2;   //!
+  TBranch        *b_x1;   //!
+  TBranch        *b_x2;   //!
+  TBranch        *b_xf1;   //!
+  TBranch        *b_xf2;   //!
+  TBranch        *b_ZpT;   //!
+  TBranch        *b_Zeta;   //!
+  TBranch        *b_Zphi;   //!
+  TBranch        *b_ZM;   //!
+  TBranch        *b_dPhiZJet1;   //!
+  TBranch        *b_dEtaZJet1;   //!
+  TBranch        *b_pTRef1;   //!
+  TBranch        *b_dPhiZJet2;   //!
+  TBranch        *b_dEtaZJet2;   //!
+  TBranch        *b_pTRef2;   //!
+  TBranch        *b_jetDPhi;   //!
+  TBranch        *b_jetDEta;   //!
+  TBranch        *b_jetPtRatio;   //!
+  TBranch        *b_weight;   //!
+  TBranch        *b_weight_xs;   //!
+  TBranch        *b_weight_prescale;   //!
+  TBranch        *b_weight_muon_trig;   //!
+  TBranch        *b_njets;   //!
+  TBranch        *b_jet_E;   //!
+  TBranch        *b_jet_pt;   //!
+  TBranch        *b_jet_phi;   //!
+  TBranch        *b_jet_eta;   //!
+  TBranch        *b_jet_rapidity;   //!
+  TBranch        *b_jet_HECFrac;   //!
+  TBranch        *b_jet_EMFrac;   //!
+  TBranch        *b_jet_CentroidR;   //!
+  TBranch        *b_jet_FracSamplingMax;   //!
+  TBranch        *b_jet_FracSamplingMaxIndex;   //!
+  TBranch        *b_jet_LowEtConstituentsFrac;   //!
+  TBranch        *b_jet_GhostMuonSegmentCount;   //!
+  TBranch        *b_jet_Width;   //!
+  TBranch        *b_jet_NumTrkPt1000PV;   //!
+  TBranch        *b_jet_SumPtTrkPt1000PV;   //!
+  TBranch        *b_jet_TrackWidthPt1000PV;   //!
+  TBranch        *b_jet_NumTrkPt500PV;   //!
+  TBranch        *b_jet_SumPtTrkPt500PV;   //!
+  TBranch        *b_jet_TrackWidthPt500PV;   //!
+  TBranch        *b_jet_JVFPV;   //!
+  TBranch        *b_jet_Jvt;   //!
+  TBranch        *b_jet_JvtJvfcorr;   //!
+  TBranch        *b_jet_JvtRpt;   //!
+  TBranch        *b_jet_SV0;   //!
+  TBranch        *b_jet_SV1;   //!
+  TBranch        *b_jet_IP3D;   //!
+  TBranch        *b_jet_SV1IP3D;   //!
+  TBranch        *b_jet_MV1;   //!
+  TBranch        *b_jet_MV2c00;   //!
+  TBranch        *b_jet_MV2c20;   //!
+  TBranch        *b_jet_MV2c20_is85;   //!
+  TBranch        *b_jet_MV2c20_SF85;   //!
+  TBranch        *b_jet_MV2c20_is77;   //!
+  TBranch        *b_jet_MV2c20_SF77;   //!
+  TBranch        *b_jet_MV2c20_is70;   //!
+  TBranch        *b_jet_MV2c20_SF70;   //!
+  TBranch        *b_jet_MV2c20_is60;   //!
+  TBranch        *b_jet_MV2c20_SF60;   //!
+  TBranch        *b_jet_isBTag;   //!
+  TBranch        *b_jet_SFBTag;   //!
+  TBranch        *b_jet_GhostArea;   //!
+  TBranch        *b_jet_ActiveArea;   //!
+  TBranch        *b_jet_VoronoiArea;   //!
+  TBranch        *b_jet_ActiveArea4vec_pt;   //!
+  TBranch        *b_jet_ActiveArea4vec_eta;   //!
+  TBranch        *b_jet_ActiveArea4vec_phi;   //!
+  TBranch        *b_jet_ActiveArea4vec_m;   //!
+  TBranch        *b_jet_ConeTruthLabelID;   //!
+  TBranch        *b_jet_TruthCount;   //!
+  TBranch        *b_jet_TruthLabelDeltaR_B;   //!
+  TBranch        *b_jet_TruthLabelDeltaR_C;   //!
+  TBranch        *b_jet_TruthLabelDeltaR_T;   //!
+  TBranch        *b_jet_PartonTruthLabelID;   //!
+  TBranch        *b_jet_GhostTruthAssociationFraction;   //!
+  TBranch        *b_jet_truth_E;   //!
+  TBranch        *b_jet_truth_pt;   //!
+  TBranch        *b_jet_truth_phi;   //!
+  TBranch        *b_jet_truth_eta;   //!
+  TBranch        *b_jet_constitScaleEta;   //!
+  TBranch        *b_jet_emScaleEta;   //!
+  TBranch        *b_jet_mucorrected_pt;   //!
+  TBranch        *b_jet_mucorrected_eta;   //!
+  TBranch        *b_jet_mucorrected_phi;   //!
+  TBranch        *b_jet_mucorrected_m;   //!
+  TBranch        *b_nmuon;   //!
+  TBranch        *b_muon_pt;   //!
+  TBranch        *b_muon_eta;   //!
+  TBranch        *b_muon_phi;   //!
+  TBranch        *b_muon_m;   //!
+  TBranch        *b_muon_effSF;   //!
+};  
+#endif

--- a/ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h
+++ b/ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h
@@ -1,0 +1,34 @@
+#ifndef ZJetBalanceMiniTreeAnaSkeleton_H
+#define ZJetBalanceMiniTreeAnaSkeleton_H
+
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaBase.h>
+
+//algorithm wrapper
+#include <TH1F.h>
+#include <TH2F.h>
+
+class ZJetBalanceMiniTreeAnaSkeleton : public ZJetBalanceMiniTreeAnaBase
+{
+ public:
+  // this is a standard constructor
+  ZJetBalanceMiniTreeAnaSkeleton();
+  
+  virtual EL::StatusCode configure (); 
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+  
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(ZJetBalanceMiniTreeAnaSkeleton, 1);
+  
+ private:
+  // declaration for your histograms
+  TH1F* m_h_ZM; //!
+
+};  
+#endif

--- a/ZJetBalance/ZJetBalanceMiniTree_GenBalanceHistograms.h
+++ b/ZJetBalance/ZJetBalanceMiniTree_GenBalanceHistograms.h
@@ -1,0 +1,111 @@
+#ifndef ZJetBalanceMiniTree_GenBalanceHistograms_H
+#define ZJetBalanceMiniTree_GenBalanceHistograms_H
+
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaBase.h>
+
+//algorithm wrapper
+#include <TH1F.h>
+#include <TH2F.h>
+
+class ZJetBalanceMiniTree_GenBalanceHistograms : public ZJetBalanceMiniTreeAnaBase
+{
+ public:
+  // this is a standard constructor
+  ZJetBalanceMiniTree_GenBalanceHistograms();
+  
+  virtual EL::StatusCode configure (); 
+  virtual EL::StatusCode setupJob (EL::Job& job);
+  virtual EL::StatusCode fileExecute ();
+  virtual EL::StatusCode histInitialize ();
+  virtual EL::StatusCode initialize ();
+  virtual EL::StatusCode execute ();
+  virtual EL::StatusCode postExecute ();
+  virtual EL::StatusCode finalize ();
+  virtual EL::StatusCode histFinalize ();
+  
+  // this is needed to distribute the algorithm to the workers
+  ClassDef(ZJetBalanceMiniTree_GenBalanceHistograms, 1);
+  
+ private:
+  int    m_nBinsXForResponseHist; //! configurable parameter
+  double m_maxXForResponseHist; //! configurable parameter
+  double m_minXForResponseHist; //! configurable parameter
+  bool   m_doPUreweighting; //! configurable parameter
+  double m_cutDPhiZJet; //! configurable parameter
+  double m_ZMassWindow; //! configurable parameter
+  bool m_fillMuonBefore; //! configurable parameter
+
+  // declaration for your histograms
+  TH1F* m_h_muon1_pT_beforecut; //!
+  TH1F* m_h_muon1_eta_beforecut; //!
+  TH1F* m_h_muon1_phi_beforecut; //!
+  TH1F* m_h_muon2_pT_beforecut; //!
+  TH1F* m_h_muon2_eta_beforecut; //!
+  TH1F* m_h_muon2_phi_beforecut; //!
+  TH1F* m_h_muon1_pT; //!
+  TH1F* m_h_muon1_eta; //!
+  TH1F* m_h_muon1_phi; //!
+  TH1F* m_h_muon2_pT; //!
+  TH1F* m_h_muon2_eta; //!
+  TH1F* m_h_muon2_phi; //!
+
+  // histograms
+  TH1F* m_h_RunNumber; //!
+  TH1F* m_h_ZpT; //!
+  TH1F* m_h_Zeta; //!
+  TH1F* m_h_Zphi; //!
+  TH1F* m_h_ZM; //!
+  TH1F* m_h_Z_jet_dPhi; //!
+  TH1F* m_h_Z_jet_dEta; //!
+  TH1F* m_h_nJets; //!
+  TH1F* m_h_jet_eta; //!
+  TH1F* m_h_jet_pt; //!
+  TH1F* m_h_jet_phi; //!
+  TH1F* m_h_jet_eta_b; //!
+  TH1F* m_h_jet_pt_b; //!
+  TH1F* m_h_jet_phi_b; //!
+  TH1F* m_h_jet_eta_c; //!
+  TH1F* m_h_jet_pt_c; //!
+  TH1F* m_h_jet_phi_c; //!
+  TH1F* m_h_jet_eta_l; //!
+  TH1F* m_h_jet_pt_l; //!
+  TH1F* m_h_jet_phi_l; //!
+  TH1F* m_h_averageInteractionsPerCrossing; //!
+  TH2F* m_h_jet_pt_bin; //!
+  TH1F* m_h_pt_binning_info; //!
+  TH1F* m_h_eta_binning_info; //!
+  TH1F* m_h_prwfactor; //!
+  TH1F* m_h_muonTrigFactor; //!
+  TH1F* m_h_muon1EffFactor; //!
+  TH1F* m_h_muon2EffFactor; //!
+  TH1F* m_h_nJets_beforecut; //!
+  TH1F* m_h_jet_eta_beforecut; //!
+  TH1F* m_h_jet_pt_beforecut; //!
+  TH1F* m_h_jet_eta_beforecut_b; //!
+  TH1F* m_h_jet_pt_beforecut_b; //!
+  TH1F* m_h_jet_eta_beforecut_c; //!
+  TH1F* m_h_jet_pt_beforecut_c; //!
+  TH1F* m_h_jet_eta_beforecut_l; //!
+  TH1F* m_h_jet_pt_beforecut_l; //!
+  TH1F* m_h_cutflow; //!
+  TH1F* m_h_cutflow_weighted; //!
+  TH1F* m_h_cutflow_weighted_final; //!
+  
+  
+  Double_t*       m_pT_binning; //!
+  Int_t           m_n_pT_binning; //!
+  Double_t*       m_eta_binning; //!
+  Int_t           m_n_eta_binning; //!
+
+  static void DecodeBinning(TString binning_str, Double_t* binning_array, Int_t& n_binning);
+  int GetPtBin(const double& _pt);
+  int GetEtaBin(const double& _eta);
+  inline void FillFlavorHistograms(TH1F* h_b, TH1F* h_c, TH1F* h_l, const int& truthLabel, const float& value, const float& weight);
+
+  std::pair<TH1F*, TH1F*> ReturnCutflowPointers();
+  std::vector< std::vector<TH1F*> > m_balance_hists;
+  std::vector< std::vector<TH1F*> > m_balance_hists_b;
+  std::vector< std::vector<TH1F*> > m_balance_hists_c;
+  std::vector< std::vector<TH1F*> > m_balance_hists_l;
+};  
+#endif

--- a/data/ZJetBalanceMiniTreeAnaSkeleton.config
+++ b/data/ZJetBalanceMiniTreeAnaSkeleton.config
@@ -1,0 +1,30 @@
+HistPrefix		   MyAnalysis_
+
+Debug                      false
+#pT_binning                 20,25,30,35,45,60,80,110,160,210,260,310,500
+#pT_binning                 25,30,35,45,60,80,110,160,500
+#eta_binning                -2.5,-1.0,0,1.0,2.5
+pT_binning                 30,50,75,100,200
+eta_binning                -2.5,2.5
+
+# response (jet pT / rel Z pT)
+nBinsXForResponseHist      300
+minXForResponseHist        0
+maxXForResponseHist        30
+
+cutDPhiZJet		   2.8
+ZMassWindow		   15
+
+BTagJets                False
+# 85, 77, 70, 60
+BTagOP                  70
+
+DoPileupReweighting	   true
+#DoPileupReweighting	   false
+#LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595.root
+LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595_RUN2-UPD4-04.root
+#PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.361106.e3601_a766_a767_r6264.v00_METADATA.root
+PRWFiles                  $ROOTCOREBIN/data/ZJetBalance/prw.361107.e3601_a766_a767_r6264.v00_METADATA.root
+#PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.410004.e3601_a766_a767_r6264.v00_METADATA.root
+
+## last option must be followed by a new line ##

--- a/data/ZJetBalanceMiniTreeAnaSkeleton.config
+++ b/data/ZJetBalanceMiniTreeAnaSkeleton.config
@@ -1,30 +1,19 @@
-HistPrefix		   MyAnalysis_
+HistPrefix		   AnaSkeleton_
+
+# AdditionalWeight typical use case is DxAOD skimming efficiency factor
+AdditionalWeight	   1.0
 
 Debug                      false
-#pT_binning                 20,25,30,35,45,60,80,110,160,210,260,310,500
-#pT_binning                 25,30,35,45,60,80,110,160,500
-#eta_binning                -2.5,-1.0,0,1.0,2.5
-pT_binning                 30,50,75,100,200
-eta_binning                -2.5,2.5
-
-# response (jet pT / rel Z pT)
-nBinsXForResponseHist      300
-minXForResponseHist        0
-maxXForResponseHist        30
-
-cutDPhiZJet		   2.8
-ZMassWindow		   15
-
-BTagJets                False
+BTagJets                   False
 # 85, 77, 70, 60
-BTagOP                  70
+BTagOP			   70
 
 DoPileupReweighting	   true
 #DoPileupReweighting	   false
 #LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595.root
 LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595_RUN2-UPD4-04.root
 #PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.361106.e3601_a766_a767_r6264.v00_METADATA.root
-PRWFiles                  $ROOTCOREBIN/data/ZJetBalance/prw.361107.e3601_a766_a767_r6264.v00_METADATA.root
+PRWFiles                   $ROOTCOREBIN/data/ZJetBalance/prw.361107.e3601_a766_a767_r6264.v00_METADATA.root
 #PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.410004.e3601_a766_a767_r6264.v00_METADATA.root
 
 ## last option must be followed by a new line ##

--- a/data/ZJetBalanceMiniTree_GenBalanceHistograms.config
+++ b/data/ZJetBalanceMiniTree_GenBalanceHistograms.config
@@ -1,0 +1,31 @@
+HistPrefix		   GenHists_
+
+# AdditionalWeight typical use case is DxAOD skimming efficiency factor
+AdditionalWeight	   1.0
+
+Debug                      false
+
+pT_binning                 30,50,75,100,200
+eta_binning                -2.5,2.5
+
+# response (jet pT / rel Z pT)
+nBinsXForResponseHist      300
+minXForResponseHist        0
+maxXForResponseHist        30
+
+cutDPhiZJet		   2.8
+ZMassWindow		   15
+
+BTagJets                   False
+# 85, 77, 70, 60
+BTagOP			   70
+
+DoPileupReweighting	   true
+#DoPileupReweighting	   false
+#LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595.root
+LumiCalcFiles		   $ROOTCOREBIN/data/ZJetBalance/ilumicalc_histograms_None_271298-271595_RUN2-UPD4-04.root
+#PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.361106.e3601_a766_a767_r6264.v00_METADATA.root
+PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.361107.e3601_a766_a767_r6264.v00_METADATA.root
+#PRWFiles		   $ROOTCOREBIN/data/ZJetBalance/prw.410004.e3601_a766_a767_r6264.v00_METADATA.root
+
+## last option must be followed by a new line ##

--- a/util/runZJetBalanceMiniTreeAna.cxx
+++ b/util/runZJetBalanceMiniTreeAna.cxx
@@ -1,0 +1,300 @@
+#include <xAODRootAccess/Init.h>
+#include <SampleHandler/SampleHandler.h>
+#include <SampleHandler/ScanDir.h>
+#include <SampleHandler/DiskListEOS.h>
+#include <SampleHandler/DiskListXRD.h>
+#include <SampleHandler/DiskListLocal.h>
+#include <SampleHandler/ToolsDiscovery.h>
+#include <EventLoop/Job.h>
+#include <EventLoop/DirectDriver.h>
+#include <EventLoop/OutputStream.h>
+#include <EventLoopGrid/PrunDriver.h>
+#include <ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h>
+
+#include <string>
+#include <sys/stat.h>
+#include <fstream>
+#include <unistd.h>
+
+#include <TEnv.h>
+#include <TString.h>
+#include <TSystem.h>
+
+
+int main( int argc, char* argv[] ) {
+
+  //
+  // Create the EventLoop job:
+  //
+  EL::Job job;
+  
+  //
+  // Init various job options
+  //
+  std::string configName = "$ROOTCOREBIN/data/ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.config";
+  std::string treeName   = "outTree";
+  std::string submitDir  = "submitDir";
+  std::string outputName = "";
+  
+  std::string samplePath = ".";
+  std::string inputTag;
+  std::string outputTag = "";
+  
+  //
+  // Set up various job options
+  //
+  
+  /////////// Retrieve job arguments //////////////////////////
+  std::vector< std::string> options;
+  for(int ii=1; ii < argc; ++ii){
+    options.push_back( std::string(argv[ii]) );
+  }
+  
+  if (argc > 1 && options.at(0).compare("-h") == 0) {
+    std::cout << std::endl
+         << " job submission" << std::endl
+         << std::endl
+         << " Optional arguments:" << std::endl
+         << "  -h               Prints this menu" << std::endl
+         << "  -inFile          Path to a folder, root file, or text file" << std::endl
+         << "  -outputTag       Version string to be appended to job name" << std::endl
+         << "  -submitDir       Name of output directory" << std::endl
+         << "  -configName      Path to config file" << std::endl
+         << "  -syst            Name AND value for systematic" << std::endl
+         << std::endl;
+    exit(1);
+  }
+  
+  int iArg = 0;
+  while(iArg < argc-1) {
+
+    if (options.at(iArg).compare("-h") == 0) {
+       // Ignore if not first argument
+       ++iArg;
+
+    } else if (options.at(iArg).compare("-inFile") == 0) {
+       char tmpChar = options.at(iArg+1)[0];
+       if (iArg+1 == argc || tmpChar == '-' ) {
+         std::cout << " -inFile should be followed by a file or folder" << std::endl;
+         return 1;
+       } else {
+         samplePath = options.at(iArg+1);
+         iArg += 2;
+       }
+
+    } else if (options.at(iArg).compare("-outputTag") == 0) {
+       char tmpChar = options.at(iArg+1)[0];
+       if (iArg+1 == argc || tmpChar == '-' ) {
+         std::cout << " -outputTag should be followed by a job version string" << std::endl;
+         return 1;
+       } else {
+         outputTag = options.at(iArg+1);
+         iArg += 2;
+       }
+
+    } else if (options.at(iArg).compare("-submitDir") == 0) {
+       char tmpChar = options.at(iArg+1)[0];
+       if (iArg+1 == argc || tmpChar == '-' ) {
+         std::cout << " -submitDir should be followed by a folder name" << std::endl;
+         return 1;
+       } else {
+         submitDir = options.at(iArg+1);
+         iArg += 2;
+       }
+
+    } else if (options.at(iArg).compare("-configName") == 0) {
+       char tmpChar = options.at(iArg+1)[0];
+       if (iArg+1 == argc || tmpChar == '-' ) {
+         std::cout << " -configName should be followed by a config file" << std::endl;
+         return 1;
+       } else {
+         configName = options.at(iArg+1);
+         iArg += 2;
+       }
+
+    } else if (options.at(iArg).compare("-treeName") == 0) {
+       char tmpChar = options.at(iArg+1)[0];
+       if (iArg+1 == argc || tmpChar == '-' ) {
+         std::cout << " -treeName should be followed by a tree name" << std::endl;
+         return 1;
+       } else {
+         treeName = options.at(iArg+1);
+         iArg += 2;
+       }
+
+    } else{
+      std::cout << "Couldn't understand argument " << options.at(iArg) << std::endl;
+      return 1;
+    }
+
+  }//while arguments
+
+  bool f_grid = false;
+  bool f_lxbatch = false;  
+  
+
+  // Construct the samples to run on:
+  SH::SampleHandler sh;
+  std::string containerName;
+  std::string userName = getlogin();
+  std::vector< std::string > outputContainerNames; //for grid only
+
+  //Check if input is a directory or a file
+  struct stat buf;
+  stat(samplePath.c_str(), &buf);
+  if( samplePath.substr(0, 4).find("eos") != std::string::npos){
+    SH::DiskListEOS list(samplePath.c_str());
+    if (inputTag.size() > 0){
+      SH::scanDir (sh, list, inputTag); //Run on all files within dir containing inputTag
+    }else{
+      SH::scanDir (sh, list); //Run on all files within dir
+    }
+    std::cout << "Running on EOS directory " << samplePath << std::endl;
+  }else if( S_ISDIR(buf.st_mode) ){ //if it is a local directory
+    SH::DiskListLocal list (samplePath);
+    if (inputTag.size() > 0){
+      SH::scanDir (sh, list, inputTag); //Run on all files within dir containing inputTag
+    }else{
+      SH::scanDir (sh, list); //Run on all files within dir
+    }
+    std::cout << "Running Locally on directory  " << samplePath << std::endl;
+
+  } else {  //if it is a file
+    if( samplePath.substr( samplePath.size()-4 ).find(".txt") != std::string::npos){ //It is a text file of samples
+      if( samplePath.find("grid") != std::string::npos ) //It is samples for the grid
+        f_grid = true;
+
+      std::ifstream inFile( samplePath );
+      while(std::getline(inFile, containerName) ){
+        if (containerName.size() > 1 && containerName.find("#") != 0 ){
+          std::cout << "Adding container " << containerName << std::endl;
+          if(f_grid){
+            SH::scanDQ2( sh, containerName);
+            //Add output container name to file of containers
+            //follows grid format: "user."+userName+".%in:name[1]%.%in:name[2]%.%in:name[3]%"+outputTag
+            int startPosition = 0;
+            int namePosition = 0;
+            // add for JetETMiss "private" samples
+            //startPosition = containerName.find_first_of(".", namePosition)+1;
+            //namePosition = containerName.find_first_of(".", namePosition)+1;
+            namePosition = containerName.find_first_of(".", namePosition)+1;
+            namePosition = containerName.find_first_of(".", namePosition)+1;
+            namePosition = containerName.find_first_of(".", namePosition)+1;
+            std::string outstr = "user."+userName+"."+containerName.substr(startPosition, namePosition)+outputTag+"/";
+            outputContainerNames.push_back( outstr );
+          }else{
+            //Get full path of file
+            char fullPath[300];
+            realpath( containerName.c_str(), fullPath );
+	    std::string thisPath = fullPath;
+            //split into fileName and directory two levels above file
+	    std::string fileName = thisPath.substr(containerName.find_last_of("/")+1);
+            thisPath = thisPath.substr(0, thisPath.find_last_of("/"));
+            thisPath = thisPath.substr(0, thisPath.find_last_of("/"));
+            std::cout << "path and filename are " << thisPath << " and " << fileName << std::endl;
+
+            SH::DiskListLocal list (thisPath);
+            //SH::SampleHandler sh_tmp;
+            //SH::scanDir (sh_tmp, list);
+            //sh.add( sh_tmp.findByName, ("*"+fileName).c_str() );
+            SH::scanDir (sh, list, fileName); // specifying one particular file for testing
+          }
+        }
+      }
+
+    }else{ //It is a single root file to run on
+      //Get full path of file
+      char fullPath[300];
+      realpath( samplePath.c_str(), fullPath );
+      std::string thisPath = fullPath;
+      //split into fileName and directory two levels above file
+      std::string fileName = thisPath.substr(thisPath.find_last_of("/")+1);
+      thisPath = thisPath.substr(0, thisPath.find_last_of("/"));
+      
+      std::cout << "path and file " << thisPath << " and " << fileName << std::endl;
+      SH::ScanDir().sampleDepth(0).samplePattern(fileName).scan(sh, thisPath);
+      
+    }
+  }//it's a file  
+
+
+  ///////// Set output container name //////////////
+  if( outputTag.size() > 0)
+    outputTag = "."+outputTag+"/";
+  else
+    outputTag = "/";
+
+  if(f_grid)
+    outputName = "user."+userName+".%in:name[1]%.%in:name[2]%.%in:name[3]%"+outputTag;
+  // for JetETMiss "private" samples
+  //  outputName = "user."+userName+".%in:name[3]%.%in:name[4]%.%in:name[5]%"+outputTag;
+  else
+    outputName = "%in:name%"+outputTag;
+  
+  sh.setMetaString( "nc_tree", treeName );
+  sh.setMetaString( "nc_grid_filter", "*");  //Data files on grid to not end in .root
+  sh.print();
+  
+  job.sampleHandler( sh );
+  // To automatically delete submitDir
+  job.options()->setDouble(EL::Job::optRemoveSubmitDir, 1);
+
+  //
+  //  Set the number of events
+  //
+  TEnv* config = new TEnv(gSystem->ExpandPathName( configName.c_str() ));
+  int nEvents = config->GetValue("MaxEvent",       -1);
+  if(nEvents > 0)
+    job.options()->setDouble(EL::Job::optMaxEvents, nEvents);
+  
+  //
+  // Now the Event/Objection Selection
+  //
+
+  
+  //
+  // The Multijet analysis 
+  ZJetBalanceMiniTreeAnaSkeleton* procMiniTree = new ZJetBalanceMiniTreeAnaSkeleton();
+  procMiniTree->setName("ProcZJetBalance")->setConfig( configName.c_str() );
+  
+  //
+  // Add configured algos to event loop job
+  //
+  job.algsAdd( procMiniTree );
+  
+  //
+  // Submit the job
+  //
+  
+  if(f_grid){
+    EL::PrunDriver driver;
+    driver.options()->setString("nc_outputSampleName", outputName);
+
+    driver.options()->setDouble(EL::Job::optGridNFilesPerJob, 2);
+    //driver.options()->setString(EL::Job::optRootVer, "5.34.25");
+    //driver.options()->setString(EL::Job::optCmtConfig, "x86_64-slc6-gcc48-opt");
+    //driver.options()->setDouble("nc_nGBPerJob", 1);
+    //driver.options()->setString("nc_excludeSite", ???);
+    //driver.options()->setString(EL::Job::optGridMergeOutput, "false");
+    driver.options()->setDouble(EL::Job::optGridMemory,10240); // 10 GB
+
+    //driver.submit(job, submitDir); // with monitoring
+    driver.submitOnly(job, submitDir); //without monitoring
+  }else if( f_lxbatch){
+    std::cout << "Currently not implemented! " << std::endl;
+  }else{
+    // Run the job using the local/direct driver:
+    EL::DirectDriver driver;
+    driver.options()->setString("nc_outputSampleName", outputName);
+    driver.submit( job, submitDir );
+  }
+  
+  ///// For grid, save list of ouput containers to the submission directory /////
+  std::ofstream fileList((submitDir+"/outputContainers.txt"), std::ios_base::out);
+  for( unsigned int iCont=0; iCont < outputContainerNames.size(); ++iCont){
+    fileList << outputContainerNames.at(iCont)+"\n";
+  }
+  fileList.close();
+  
+  return 0;
+}


### PR DESCRIPTION
Dear all, 

As we discussed, for our future with many independent analysis on MiniTree, 
I created MiniTree analysis base class. 
- ZJetBalanceMiniTreeAnaBase : base class
- ZJetBalanceMiniTreeAnaSkeleton.h : skeleton code inherited from base class (You may start your development from this code, see below more details)
- ZJetBalanceMiniTree_GenBalanceHistograms : analysis implemented (equivalent with ProcessZJetBalanceMiniTree)

And I added one executable, 
- utils/runZJetBalanceMiniTreeAna.cxx 

Some instruction to add new MiniTree analysis code

Prepare the new codes based on Skeleton codes.

```
sed 's/AnaSkeleton/NewAlgo/g' Root/ZJetBalanceMiniTreeAnaSkeleton.cxx > Root/ZJetBalanceMiniTreeNewAlgo.cxx
sed 's/AnaSkeleton/NewAlgo/g' ZJetBalance/ZJetBalanceMiniTreeAnaSkeleton.h > ZJetBalance/ZJetBalanceMiniTreeNewAlgo.h
```

Edit LinkDef.h, to add

```
#include <ZJetBalance/ZJetBalanceMiniTreeNewAlgo.h>
```

and 

```
#pragma link C++ class ZJetBalanceMiniTreeNewAlgo;
```

then, 

```
rc find_packages
rc compile
```

After the code being ready, you may integrate it to the executable, 

```
util/runZJetBalanceMiniTreeAna.cxx
```

The executable can be run in the following way

```
runZJetBalanceMiniTreeAna -inFile  ${testinput} -submitDir submitDirTest -algorithm 2
```

Have fun! 

Best regards,
Yasu Okumura
