### PR TITLE
add a convenient scripts for API access

### DIFF
--- a/scripts/MyDxAODInfoGetterOk.py
+++ b/scripts/MyDxAODInfoGetterOk.py
@@ -1,0 +1,99 @@
+# setupATLAS
+# localSetupPyAMI
+
+
+import pyAMI.client
+import pyAMI.atlas.api as AtlasAPI
+
+
+class MyDxAODInfoGetterOk():
+    
+    ################################################
+    def __init__(s):
+        s.client = pyAMI.client.Client('atlas')
+        AtlasAPI.init()
+    
+    ################################################
+    def getInfo(s,dsid,daodType,ptag,rtag=None):
+        daod=s.getLdn(dsid,daodType,ptag,rtag)
+        
+        if not daod:
+            print 'ERROR> in getLdn, please find your query is enough to select one DS'
+            print '       Currently follows are used: dsid=',dsid,'daodType=',daodType,'ptag=',ptag,'rtag=',rtag
+            return
+        
+        aod  = s.getOriginalAOD(daod)
+        
+        if not aod:
+            print 'ERROR> no AOD File is not found for ldn=',ldn
+            return
+        
+        aodInfo  = s.encodeDSInfo(aod)
+        daodInfo = s.encodeDSInfo(daod)
+        
+        aodEvents  = float(aodInfo['events'])
+        daodEvents = float(daodInfo['events'])
+        skimmingRate = daodEvents/aodEvents
+        return {'events':daodInfo['events'], 'xsec':daodInfo['xsec'], 'fit_eff':daodInfo['fit_eff'], 'daod_ldn':daod, 'aod_ldn':aod, 'dsid':dsid, 'skim_eff':skimmingRate, 'daod_events':daodEvents, 'aod_events':aodEvents}
+    
+    ################################################
+    def encodeDSInfo(s, ldn):
+        datasetinfo      = AtlasAPI.get_dataset_info(s.client,ldn)
+        neventsAMI       = float(datasetinfo[0]['totalEvents'])
+        crosssectionAMI  = float(datasetinfo[0]['crossSection'])
+        if 'approx_GenFiltEff' in datasetinfo[0].keys():
+            filtereffAMI     = float(datasetinfo[0]['approx_GenFiltEff'])
+        else :
+            filtereffAMI     = None
+        return {'events':neventsAMI, 'xsec':crosssectionAMI, 'fit_eff':filtereffAMI, 'ldn':ldn}
+    
+    ################################################
+    def getLdn(s,dsid,daodType,ptag,rtag=None):
+        pattern=''
+        if not rtag:
+            pattern='mc15_13TeV.'+dsid+'%.merge.DAOD_'+daodType+'%'+ptag+'%'
+        else :
+            pattern='mc15_13TeV.'+dsid+'%.merge.DAOD_'+daodType+'%'+rtag+'%'+ptag+'%'
+            
+        samples=AtlasAPI.list_datasets(s.client, patterns = [pattern])
+        
+        if len(samples)==0:
+            print 'NO DAOD_%s DS found for %s'%(DAOD_Type, dsid)            
+            return None
+        elif len(samples)!=1:
+            print 'More than one DAOD_%s DS round for %s'%(DAOD_Type, dsid)
+            for sample in samples:
+                print sample
+            print 'please set rtag to select one proper one'
+            return None
+        
+        return samples[0]['ldn']
+    
+    ################################################
+    def getOriginalEVNT(s,ldn):
+        provs=AtlasAPI.get_dataset_prov(s.client, ldn)
+        
+        evnt=None
+        
+        for sample in provs['node']:
+            if 'evgen.EVNT' in sample['logicalDatasetName']:
+                evnt=sample['logicalDatasetName']
+        
+        return evnt
+    
+    ################################################
+    def getOriginalAOD(s,ldn):
+        provs=AtlasAPI.get_dataset_prov(s.client, ldn)
+        
+        evnt=None
+        
+        for sample in provs['node']:
+            if '.AOD.' in sample['logicalDatasetName']:
+                evnt=sample['logicalDatasetName']
+                break;
+            
+        return evnt
+    
+if __name__ == '__main__':
+    getter = MyDxAODInfoGetterOk()
+    info=getter.getInfo(dsid='361372',daodType='SUSY2',ptag='p2375')

--- a/scripts/RunMyDxAODInfoGetterOk.py
+++ b/scripts/RunMyDxAODInfoGetterOk.py
@@ -1,0 +1,64 @@
+# setupATLAS
+# localSetupPyAMI
+# voms-proxy-init -voms atlas
+
+from MyDxAODInfoGetterOk import MyDxAODInfoGetterOk
+
+
+daodType='SUSY2'
+ptag='p2375'
+rtag=None # add if needed
+outputfilename='amiDumpInfo.txt'
+
+DSIDs=[
+    # Zee
+    '361372', '361373', '361374',
+    '361375', '361376', '361377',
+    '361378', '361379', '361380',
+    '361381', '361382', '361383',
+    # Zmumu
+    '361396', '361397', '361398',
+    '361399', '361400', '361401',
+    '361402', '361403', '361404',
+    '361405', '361406', '361407',
+    # Z tau tau
+    '361420', '361421', '361422', 
+    '361423', '361424', '361425', 
+    '361426', '361427', '361428', 
+    '361429', '361430', '361431'
+    ]
+
+getter = MyDxAODInfoGetterOk()
+
+content1=[]
+content2=[]
+content3=[]
+
+for dsid in DSIDs :
+    print 'information for '+dsid+' is being dumped..'
+    info=getter.getInfo(dsid=dsid,daodType=daodType,ptag=ptag,rtag=rtag)
+    # for DS list to be used for submission
+    content1.append(info['daod_ldn'])
+    
+    # for XS file
+    # 361106 1.9506E+06 1.0000E+00 19993000
+    unit_pb=1e6
+    content2.append('#'+info['daod_ldn'])
+    content2.append('%s %e %e %d'%(info['dsid'], float(info['xsec'])*unit_pb, float(info['fit_eff']), int(info['aod_events'])) )
+    
+    # used in the final protting code                
+    content3.append('dXAODSkimmingEfficiency[%d]=%f'%(int(info['dsid']), float(info['skim_eff'])) )
+
+
+outputfile=open(outputfilename, 'w')
+
+for line in content1:
+    print >>outputfile,line
+
+print >>outputfile, ''
+for line in content2:
+    print >>outputfile,line
+
+print >>outputfile, ''
+for line in content3:
+    print >>outputfile,line


### PR DESCRIPTION
Dear Brian and Gabriel,

I added a new possibly convenient script for you 
to be free from browsing slow AMI page. 

```
# at some directory for your convenience to create some dump files 
setupATLAS
localSetupPyAMI
voms-proxy-init -voms atlas

# copy two files in the current directory
cp ZJetBalance/scripts/RunMyDxAODInfoGetterOk.py ./
cp ZJetBalance/scripts/MyDxAODInfoGetterOk.py ./

# run python
python RunMyDxAODInfoGetterOk.py

# modify RunMyDxAODInfoGetterOk.py as you wish
```
